### PR TITLE
Sleep more often during FAQs import.

### DIFF
--- a/app/importers/parature_faq_data.rb
+++ b/app/importers/parature_faq_data.rb
@@ -25,7 +25,7 @@ class ParatureFaqData
     Rails.logger.info "Importing #{@resource}"
 
     data = Array(1..379).map do |id|
-      sleep 10 if id % 100 == 0 && should_throttle
+      sleep 10 if id % 10 == 0 && should_throttle
       begin
         extract_hash_from_resource(id)
       rescue OpenURI::HTTPError, Errno::ENOENT => e


### PR DESCRIPTION
I kept getting a 503 error whenever I ran the import in staging. I
figured that the sleep added by Tim must have been to avoid hitting the
same problem in dev. Not sure why full imports work in dev without this
change but not in staging, but after testing this in staging the import
worked.
