### PR TITLE
Suppress unpermitted parameters errors

### DIFF
--- a/app/controllers/api/v2_controller.rb
+++ b/app/controllers/api/v2_controller.rb
@@ -1,13 +1,6 @@
 class Api::V2Controller < ApiController
   before_action :authenticate_by_api_key
 
-  ActionController::Parameters.action_on_unpermitted_parameters = :raise
-
-  rescue_from(ActionController::UnpermittedParameters) do |e|
-    render json:   { error:  { unknown_parameters: e.params } },
-           status: :bad_request
-  end
-
   rescue_from(Exceptions::InvalidDateRangeFormat) do |_e|
     render json:   { error:  'Invalid Date Range Format' },
            status: :bad_request

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,4 +1,11 @@
 class ApiController < ActionController::Base
+  ActionController::Parameters.action_on_unpermitted_parameters = :raise
+
+  rescue_from(ActionController::UnpermittedParameters) do |e|
+    render json:   { error:  { unknown_parameters: e.params } },
+           status: :bad_request
+  end
+
   def not_found
     render json: { error: 'Not Found' }, status: :not_found
   end

--- a/spec/controllers/api/v2_controller_spec.rb
+++ b/spec/controllers/api/v2_controller_spec.rb
@@ -16,7 +16,6 @@ describe Api::V2Controller, type: :controller do
 
   class InheritsFromApiV2Controller < described_class
     def foo
-      ActionController::Parameters.new(params).permit([:q, :api_key])
       render text: 'ok', status: :ok
     end
 
@@ -68,27 +67,15 @@ describe Api::V2Controller, type: :controller do
             expect(response.status).to eq(200)
           end
         end
-      end
-    end
-
-    describe 'bad request' do
-      include_context 'user with API Key'
-
-      context 'with unpermitted parameter' do
-        it 'responds with 400 error' do
-          request.headers['Api-Key'] = user.api_key
-          get :foo, not_a: :valid_paramter
-          expect(response.status).to eq(400)
+        context 'with invalid date range exception' do
+          it 'responds with 400 error' do
+            request.headers['Api-Key'] = user.api_key
+            get :bad_date_range
+            expect(response.status).to eq(400)
+          end
         end
       end
 
-      context 'with invalid date range exception' do
-        it 'responds with 400 error' do
-          request.headers['Api-Key'] = user.api_key
-          get :bad_date_range
-          expect(response.status).to eq(400)
-        end
-      end
     end
 
   end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -1,11 +1,43 @@
 require 'spec_helper'
 
 describe ApiController, type: :controller do
-  # include_context 'V2 headers'
-  describe '#not_found' do
-    it 'responds with a 404 status' do
-      get :not_found
-      expect(response.status).to eq(404)
+
+  class InheritsFromApiController < described_class
+    def foo
+      ActionController::Parameters.new(params).permit([:q])
+      render text: 'ok', status: :ok
     end
+  end
+
+  describe InheritsFromApiController do
+    before do
+      Rails.application.routes.draw do
+        get '/foo' => 'inherits_from_api#foo'
+        get '/not_found' => 'inherits_from_api#not_found'
+      end
+    end
+    after  { Rails.application.reload_routes! }
+
+    describe '#not_found' do
+      it 'responds with a 404 status' do
+        get :not_found
+        expect(response.status).to eq(404)
+      end
+    end
+
+    describe '#foo' do
+      it 'responds with 200' do
+        get :foo, q: :freddy
+        expect(response.status).to eq(200)
+      end
+
+      context 'with unpermitted parameter' do
+        it 'responds with 400' do
+          get :foo, a: :b
+          expect(response.status).to eq(400)
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This is an initial solution, another way of doing it is adding

    config.action_controller.action_on_unpermitted_parameters = :log

to `config/environments/production.rb`, but I am not sure which solution is more suitable for our case.