### PR TITLE
Let tests run even when `before(:suite)` fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.1.0
 before_install:
   - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.2.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.2.1.deb && true
+  - sudo /usr/share/elasticsearch/bin/plugin install elasticsearch/elasticsearch-analysis-phonetic/2.2.0
   - sudo service elasticsearch start
 script:
   - bin/rake about

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ rvm:
 before_install:
   - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.2.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.2.1.deb && true
   - sudo service elasticsearch start
-
+script:
+  - bin/rake about
+  - bin/rspec
+  - bin/rake
 addons:
  code_climate:
    repo_token: b2be59fc94d6de5b889a16c640227b42d40d8aa21df90fad79dd70f2687d630c

--- a/Capfile
+++ b/Capfile
@@ -9,3 +9,4 @@ if File.directory?(cap_dir) || File.symlink?(cap_dir)
   # load 'deploy/assets'
   load 'capistrano/deploy' # remove this line to skip loading any of the default tasks
 end
+


### PR DESCRIPTION
Right now we get a success like message on travis and locally
no tests get executed and we end up with a green success message
when it should be a failure.

This is not ideal but at least we will see failures.