### PR TITLE
Carlos/fix empty q

### DIFF
--- a/lib/query.rb
+++ b/lib/query.rb
@@ -35,7 +35,7 @@ class Query
 
     @offset = options[:offset].to_i
     @size   = [options[:size].to_i, MAX_SIZE].min
-    @q      = options[:q]
+    @q      = options[:q].try(:empty?) ? nil : options[:q]
     initialize_search_fields(options)
 
     unless valid?

--- a/lib/query.rb
+++ b/lib/query.rb
@@ -30,12 +30,13 @@ class Query
 
   def initialize(options = {})
     options.reverse_merge!(size: DEFAULT_SIZE)
+    options.delete(:q) if options[:q].try(:empty?)
 
     cleanup_invalid_bytes(options, [:q])
 
     @offset = options[:offset].to_i
     @size   = [options[:size].to_i, MAX_SIZE].min
-    @q      = options[:q].try(:empty?) ? nil : options[:q]
+    @q      = options[:q]
     initialize_search_fields(options)
 
     unless valid?

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -32,9 +32,23 @@ describe Query do
       end
     end
     context 'when given an empty :q parameter' do
-      subject { described_class.new(q: "") }
+      before do
+        class TestWithSetupQuery < Query
+          setup_query(
+            q:      %i(title description),
+            query:  %i(q),
+          )
+        end
+      end
+      after do
+        Object.send(:remove_const, :TestWithSetupQuery)
+      end
+      subject {}
       it 'should behave like no :q parameter was passed' do
-        expect(subject.q).to be_nil
+        expect(TestWithSetupQuery.new(q: "").q).to be_nil
+      end
+      it 'should behave like no :q parameter was passed2' do
+        expect(ScreeningList::Query.new(q: "").q).to be_nil
       end
     end
   end

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -31,6 +31,12 @@ describe Query do
         expect { subject }.to raise_error(Query::InvalidParamsException)
       end
     end
+    context 'when given an empty :q parameter' do
+      subject { described_class.new(q: "") }
+      it 'should behave like no :q parameter was passed' do
+        expect(subject.q).to be_nil
+      end
+    end
   end
 
   describe '#generate_search_body' do


### PR DESCRIPTION
if the "q" param is present but empty, the endpoints should behave as if no "q" parameter was present.