### PR TITLE
Stop recreating indexes at the beginning of the test suite

### DIFF
--- a/spec/api/v1/tariff_rates/australia_spec.rb
+++ b/spec/api/v1/tariff_rates/australia_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Australia Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'au'
       it_behaves_like 'it contains all TariffRate::Australia results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/bahrain_spec.rb
+++ b/spec/api/v1/tariff_rates/bahrain_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Bahrain Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'bh'
       it_behaves_like 'it contains all TariffRate::Bahrain results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/chile_spec.rb
+++ b/spec/api/v1/tariff_rates/chile_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Chile Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'cl'
       it_behaves_like 'it contains all TariffRate::Chile results that match "caballos"'
     end
   end

--- a/spec/api/v1/tariff_rates/colombia_spec.rb
+++ b/spec/api/v1/tariff_rates/colombia_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Colombia Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'co'
       it_behaves_like 'it contains all TariffRate::Colombia results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/costa_rica_spec.rb
+++ b/spec/api/v1/tariff_rates/costa_rica_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Costa Rica Tariff Rates API V1', type: :request do
       subject { response }
       it_behaves_like 'a successful search request'
       it_behaves_like 'it contains all TariffRate::CostaRica results that match "horses"'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'cr'
     end
   end
 end

--- a/spec/api/v1/tariff_rates/dominican_republic_spec.rb
+++ b/spec/api/v1/tariff_rates/dominican_republic_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA DominicanRepublic Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'do'
       it_behaves_like 'it contains all TariffRate::DominicanRepublic results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/el_salvador_spec.rb
+++ b/spec/api/v1/tariff_rates/el_salvador_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA El Salvador Tariff Rates API V1', type: :request do
       subject { response }
       it_behaves_like 'a successful search request'
       it_behaves_like 'it contains all TariffRate::ElSalvador results that match "horses"'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'sv'
     end
   end
 end

--- a/spec/api/v1/tariff_rates/guatemala_spec.rb
+++ b/spec/api/v1/tariff_rates/guatemala_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Guatemala Tariff Rates API V1', type: :request do
       subject { response }
       it_behaves_like 'a successful search request'
       it_behaves_like 'it contains all TariffRate::Guatemala results that match "horses"'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'gt'
     end
   end
 end

--- a/spec/api/v1/tariff_rates/honduras_spec.rb
+++ b/spec/api/v1/tariff_rates/honduras_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Honduras Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'hn'
       it_behaves_like 'it contains all TariffRate::Honduras results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/morocco_spec.rb
+++ b/spec/api/v1/tariff_rates/morocco_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Morocco Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'ma'
       it_behaves_like 'it contains all TariffRate::Morocco results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/nicaragua_spec.rb
+++ b/spec/api/v1/tariff_rates/nicaragua_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Nicaragua Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'ni'
       it_behaves_like 'it contains all TariffRate::Nicaragua results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/oman_spec.rb
+++ b/spec/api/v1/tariff_rates/oman_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Oman Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'om'
       it_behaves_like 'it contains all TariffRate::Oman results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/panama_spec.rb
+++ b/spec/api/v1/tariff_rates/panama_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Panama Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'pa'
       it_behaves_like 'it contains all TariffRate::Panama results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/peru_spec.rb
+++ b/spec/api/v1/tariff_rates/peru_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Peru Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'pe'
       it_behaves_like 'it contains all TariffRate::Peru results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/singapore_spec.rb
+++ b/spec/api/v1/tariff_rates/singapore_spec.rb
@@ -18,7 +18,7 @@ describe 'FTA Singapore Tariff Rates API V1', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'sg'
       it_behaves_like 'it contains all TariffRate::Singapore results that match "horses"'
     end
   end

--- a/spec/api/v1/tariff_rates/south_korea_spec.rb
+++ b/spec/api/v1/tariff_rates/south_korea_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA South Korea Tariff Rates API V1', type: :request do
       subject { response }
       it_behaves_like 'a successful search request'
       it_behaves_like 'it contains all TariffRate::SouthKorea results that match "horses"'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'kr'
     end
   end
 end

--- a/spec/api/v2/tariff_rates/australia_spec.rb
+++ b/spec/api/v2/tariff_rates/australia_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Australia Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'au'
       it_behaves_like 'it contains all TariffRate::Australia results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/bahrain_spec.rb
+++ b/spec/api/v2/tariff_rates/bahrain_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Bahrain Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'bh'
       it_behaves_like 'it contains all TariffRate::Bahrain results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/chile_spec.rb
+++ b/spec/api/v2/tariff_rates/chile_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Chile Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'cl'
       it_behaves_like 'it contains all TariffRate::Chile results that match "caballos"'
     end
   end

--- a/spec/api/v2/tariff_rates/colombia_spec.rb
+++ b/spec/api/v2/tariff_rates/colombia_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Colombia Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'co'
       it_behaves_like 'it contains all TariffRate::Colombia results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/costa_rica_spec.rb
+++ b/spec/api/v2/tariff_rates/costa_rica_spec.rb
@@ -20,7 +20,7 @@ describe 'FTA Costa Rica Tariff Rates API V2', type: :request do
       subject { response }
       it_behaves_like 'a successful search request'
       it_behaves_like 'it contains all TariffRate::CostaRica results that match "horses"'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'cr'
     end
   end
 end

--- a/spec/api/v2/tariff_rates/dominican_republic_spec.rb
+++ b/spec/api/v2/tariff_rates/dominican_republic_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA DominicanRepublic Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'do'
       it_behaves_like 'it contains all TariffRate::DominicanRepublic results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/el_salvador_spec.rb
+++ b/spec/api/v2/tariff_rates/el_salvador_spec.rb
@@ -20,7 +20,7 @@ describe 'FTA El Salvador Tariff Rates API V2', type: :request do
       subject { response }
       it_behaves_like 'a successful search request'
       it_behaves_like 'it contains all TariffRate::ElSalvador results that match "horses"'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'sv'
     end
   end
 end

--- a/spec/api/v2/tariff_rates/guatemala_spec.rb
+++ b/spec/api/v2/tariff_rates/guatemala_spec.rb
@@ -20,7 +20,7 @@ describe 'FTA Guatemala Tariff Rates API V2', type: :request do
       subject { response }
       it_behaves_like 'a successful search request'
       it_behaves_like 'it contains all TariffRate::Guatemala results that match "horses"'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'gt'
     end
   end
 end

--- a/spec/api/v2/tariff_rates/honduras_spec.rb
+++ b/spec/api/v2/tariff_rates/honduras_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Honduras Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'hn'
       it_behaves_like 'it contains all TariffRate::Honduras results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/morocco_spec.rb
+++ b/spec/api/v2/tariff_rates/morocco_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Morocco Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'ma'
       it_behaves_like 'it contains all TariffRate::Morocco results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/nicaragua_spec.rb
+++ b/spec/api/v2/tariff_rates/nicaragua_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Nicaragua Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'ni'
       it_behaves_like 'it contains all TariffRate::Nicaragua results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/oman_spec.rb
+++ b/spec/api/v2/tariff_rates/oman_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Oman Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'om'
       it_behaves_like 'it contains all TariffRate::Oman results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/panama_spec.rb
+++ b/spec/api/v2/tariff_rates/panama_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Panama Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'pa'
       it_behaves_like 'it contains all TariffRate::Panama results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/peru_spec.rb
+++ b/spec/api/v2/tariff_rates/peru_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Peru Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'pe'
       it_behaves_like 'it contains all TariffRate::Peru results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/singapore_spec.rb
+++ b/spec/api/v2/tariff_rates/singapore_spec.rb
@@ -19,7 +19,7 @@ describe 'FTA Singapore Tariff Rates API V2', type: :request do
 
       subject { response }
       it_behaves_like 'a successful search request'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'sg'
       it_behaves_like 'it contains all TariffRate::Singapore results that match "horses"'
     end
   end

--- a/spec/api/v2/tariff_rates/south_korea_spec.rb
+++ b/spec/api/v2/tariff_rates/south_korea_spec.rb
@@ -20,7 +20,7 @@ describe 'FTA South Korea Tariff Rates API V2', type: :request do
       subject { response }
       it_behaves_like 'a successful search request'
       it_behaves_like 'it contains all TariffRate::SouthKorea results that match "horses"'
-      it_behaves_like "an empty result when a query doesn't match any documents"
+      it_behaves_like "an empty result when a query doesn't match any documents", sources: 'kr'
     end
   end
 end

--- a/spec/controllers/api/v1/ita_office_locations_controller_spec.rb
+++ b/spec/controllers/api/v1/ita_office_locations_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Api::V1::ItaOfficeLocationsController, type: :controller do
+  before { ItaOfficeLocation.recreate_index }
   describe '#search' do
     let(:search_params) do
       {

--- a/spec/controllers/api/v1/ita_office_locations_controller_spec.rb
+++ b/spec/controllers/api/v1/ita_office_locations_controller_spec.rb
@@ -1,44 +1,34 @@
 require 'spec_helper'
 
 describe Api::V1::ItaOfficeLocationsController, type: :controller do
-  before { ItaOfficeLocation.recreate_index }
   describe '#search' do
-    let(:search_params) do
-      {
-        'countries'   => 'US',
-        'country'     => 'US',
-        'state'       => 'DC',
-        'city'        => 'Washington',
-        'q'           => 'national',
-        'api_version' => '1',
-      }
-    end
     context 'with valid parameters' do
-      let(:search) { double('search') }
-
       before do
-        expect(ItaOfficeLocation).to receive(:search_for).with(search_params).and_return(search)
+        expect(ItaOfficeLocation).to receive(:search_for).and_return(double('search'))
+      end
+
+      it 'responds correctly with full params' do
         get :search,
             country: 'US',
             format:  :json,
             state:   'DC',
             city:    'Washington',
             q:       'national'
+
+        expect(response.status).to eq(200)
       end
 
-      it { is_expected.to respond_with(:success) }
-    end
+      it 'responds correctly with empty country param' do
+        get :search, format: :json, country: ''
 
-    it 'responds correctly with empty country param' do
-      get :search, format: :json, country: ''
+        expect(response.status).to eq(200)
+      end
 
-      expect(response.status).to eq(200)
-    end
+      it 'responds correctly with empty state param' do
+        get :search, format: :json, state: ''
 
-    it 'responds correctly with empty state param' do
-      get :search, format: :json, state: ''
-
-      expect(response.status).to eq(200)
+        expect(response.status).to eq(200)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,6 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.before(:suite) do
-    Webservices::Application.model_classes.each(&:recreate_index)
     User.create_index!
 
     # Since create_index! is asynchronous, and since specs may immediately

--- a/spec/support/empty_results_behavior.rb
+++ b/spec/support/empty_results_behavior.rb
@@ -3,8 +3,11 @@ shared_examples 'an empty result' do
   it { is_expected.to eq(0) }
 end
 
-shared_examples "an empty result when a query doesn't match any documents" do
-  let(:params) { { q: 'asdzxcasd' } }
+shared_examples "an empty result when a query doesn't match any documents" do |original_params|
+  # Allows this shared example to support queries that involves extra parameters
+  # ie.: a specific source for tariff rates
+  original_params ||= {}
+  let(:params) { original_params.merge({ q: 'asdzxcasd' }) }
   it_behaves_like 'an empty result'
 end
 


### PR DESCRIPTION
Tests already do this for the indexes they need, this one is redundant
and causes running a single spec a lot slower since it needs to wait for
all unrelated indexes to be recreated.