### PR TITLE
Restrict fetch_all search to only results doc types.

### DIFF
--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -11,12 +11,18 @@ describe Searchable do
         def self.index_names(_source = nil)
           ['test_index_name']
         end
+        def self.index_types(_source = nil)
+          ['test_index_type']
+        end
       end
 
       # I'm doing this without the use of a class which includes Indexable
       # in order to only use Searchable in this spec.
       ES.client.indices.delete(index: index_name) if ES.client.indices.exists(index: index_name)
       1_000.times { |i| ES.client.index(index: index_name, type: index_type, body: { foo: "Bar #{i}" }) }
+
+      ES.client.index(index: index_name, type: 'metadata', body: { time: Time.now })
+
       ES.client.indices.refresh(index: index_name)
     end
 
@@ -28,6 +34,7 @@ describe Searchable do
       expect(subject).to be_a(Hash)
       expect(subject[:hits].count).to eq(1_000)
       expect(subject[:hits].first[:_source]).to be_a(Hash)
+      expect(subject[:hits].find { |h| h.key?(:time) }).to be_nil
     end
   end
 end


### PR DESCRIPTION
i.e. don't fetch metadata documents.