### PR TITLE
Make v2 the default API version.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Webservices::Application.routes.draw do
   end
 
   concern :api_v1_routable do
-    path = {
+    mapping = {
       'australian_trade_leads' => 'AUSTRALIA',
       'canada_leads'           => 'CANADA',
       'fbopen_leads'           => 'FBO',
@@ -26,7 +26,7 @@ Webservices::Application.routes.draw do
       'uk_trade_leads'         => 'UK',
     }
 
-    path.each do |path, source|
+    mapping.each do |path, source|
       get "/#{path}/search(.json)" => 'trade_leads/consolidated#search', format: false, defaults: { sources: source }
     end
 
@@ -53,17 +53,17 @@ Webservices::Application.routes.draw do
   end
 
   concern :api_routable do
-    path = { 'market_researches'          => 'market_research_library',
-             'parature_faq'               => 'ita_faqs',
-             'ita_office_locations'       => 'ita_office_locations',
-             'country_commercial_guides'  => 'country_commercial_guides',
-             'business_service_providers' => 'business_service_providers',
-             'ita_zip_codes'              => 'ita_zipcode_to_post',
-             'ita_taxonomy'               => 'ita_taxonomies',
+    mapping = { 'market_researches'          => 'market_research_library',
+                'parature_faq'               => 'ita_faqs',
+                'ita_office_locations'       => 'ita_office_locations',
+                'country_commercial_guides'  => 'country_commercial_guides',
+                'business_service_providers' => 'business_service_providers',
+                'ita_zip_codes'              => 'ita_zipcode_to_post',
+                'ita_taxonomy'               => 'ita_taxonomies',
      }
-    path['eccn'] = 'eccns' unless Rails.env.production?
+    mapping['eccn'] = 'eccns' unless Rails.env.production?
 
-    path.each do |controller, path|
+    mapping.each do |controller, path|
       get "/#{path}/search(.json)" => "#{controller}#search", format: false
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,8 +102,8 @@ Webservices::Application.routes.draw do
     concerns :api_routable
   end
 
-  scope module: 'api/v1', defaults: { format: :json } do
-    concerns :api_v1_routable
+  scope module: 'api/v2', defaults: { format: :json } do
+    concerns :api_v2_routable
     concerns :api_routable
   end
 

--- a/spec/api/v1/australian_trade_leads_spec.rb
+++ b/spec/api/v1/australian_trade_leads_spec.rb
@@ -9,9 +9,9 @@ describe 'Australian Trade Leads API V1', type: :request do
 
   let(:expected_results) { JSON.parse Rails.root.join("#{File.dirname(__FILE__)}/trade_leads/australia/results.json").read }
 
-  describe 'GET /australian_trade_leads/search.json' do
+  describe 'GET /v1/australian_trade_leads/search' do
     context 'when search parameters are empty' do
-      before { get '/australian_trade_leads/search', {} }
+      before { get '/v1/australian_trade_leads/search', {} }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -30,7 +30,7 @@ describe 'Australian Trade Leads API V1', type: :request do
   describe 'GET /australian_trade_leads/search.json' do
     context 'when q is populated' do
       let(:params) { { q: 'motor' } }
-      before { get '/australian_trade_leads/search', params }
+      before { get '/v1/australian_trade_leads/search', params }
       subject { response }
 
       it_behaves_like 'a successful search request'

--- a/spec/api/v1/business_service_providers_spec.rb
+++ b/spec/api/v1/business_service_providers_spec.rb
@@ -7,10 +7,10 @@ describe 'Business Service Providers API V1', type: :request do
       "#{Rails.root}/spec/fixtures/business_service_providers/articles.json").import
   end
 
-  describe 'GET /business_service_providers/search.json' do
+  describe 'GET /v1/business_service_providers/search' do
     context 'when search parameters are empty' do
       let(:all_results) { JSON.parse Rails.root.join("#{File.dirname(__FILE__)}/business_service_providers/all_results.json").read }
-      before { get '/business_service_providers/search', {} }
+      before { get '/v1/business_service_providers/search', {} }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -30,7 +30,7 @@ describe 'Business Service Providers API V1', type: :request do
     context 'when one document matches a query and filter' do
       let(:one_match) { JSON.parse Rails.root.join("#{File.dirname(__FILE__)}/business_service_providers/one_match.json").read }
       let(:params) { { q: 'consult', ita_offices: 'el salvador' } }
-      before { get '/business_service_providers/search', params }
+      before { get '/v1/business_service_providers/search', params }
       subject { response }
 
       it_behaves_like 'a successful search request'

--- a/spec/api/v1/canada_leads_spec.rb
+++ b/spec/api/v1/canada_leads_spec.rb
@@ -7,10 +7,10 @@ describe 'Canada Leads API V1', type: :request do
       "#{Rails.root}/spec/fixtures/trade_leads/canada/canada_leads.csv").import
   end
 
-  let(:search_path) { '/canada_leads/search' }
+  let(:search_path) { '/v1/canada_leads/search' }
   let(:expected_results) { JSON.parse open("#{File.dirname(__FILE__)}/trade_leads/canada/results.json").read }
 
-  describe 'GET /canada_leads/search.json' do
+  describe 'GET /v1/canada_leads/search' do
     context 'when search parameters are empty' do
       before { get search_path, size: 100 }
       subject { response }

--- a/spec/api/v1/country_commercial_guides_spec.rb
+++ b/spec/api/v1/country_commercial_guides_spec.rb
@@ -9,11 +9,11 @@ describe 'Country Commercial Guide API V1', type: :request do
       YAML.load_file("#{File.dirname(__FILE__)}/country_commercial_guide/results.yaml")
   end
 
-  let(:search_path) { '/country_commercial_guides/search' }
+  let(:search_path) { '/v1/country_commercial_guides/search' }
   let(:params) { { size: 100 } }
   subject { response }
 
-  describe 'GET /country_commercial_guides/search.json' do
+  describe 'GET /v1/country_commercial_guides/search' do
     context 'when search parameters are empty' do
       before { get search_path, params }
 

--- a/spec/api/v1/eccn_spec.rb
+++ b/spec/api/v1/eccn_spec.rb
@@ -7,10 +7,10 @@ describe 'ECCN API V1', type: :request do
       "#{Rails.root}/spec/fixtures/eccns/eccns.csv").import
   end
 
-  describe 'GET /eccns/search.json' do
+  describe 'GET /v1/eccns/search' do
     context 'when search parameters are empty' do
       let(:all_results) { JSON.parse Rails.root.join("#{File.dirname(__FILE__)}/eccns/all_results.json").read }
-      before { get '/eccns/search', {} }
+      before { get '/v1/eccns/search', {} }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -30,7 +30,7 @@ describe 'ECCN API V1', type: :request do
     context 'when one document matches a query' do
       let(:one_match) { JSON.parse Rails.root.join("#{File.dirname(__FILE__)}/eccns/one_match.json").read }
       let(:params) { { q: 'planar absorbers' } }
-      before { get '/eccns/search', params }
+      before { get '/v1/eccns/search', params }
       subject { response }
 
       it_behaves_like 'a successful search request'

--- a/spec/api/v1/envirotech/consolidated_spec.rb
+++ b/spec/api/v1/envirotech/consolidated_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Consolidated Envirotech API V1', type: :request do
   include_context 'all Envirotech fixture data'
 
-  describe 'GET /envirotech/solutions/search.json' do
+  describe 'GET /v1/envirotech/solutions/search' do
     let(:params) { { size: 100 } }
-    before { get '/envirotech/solutions/search', params }
+    before { get '/v1/envirotech/solutions/search', params }
     subject { response }
 
     context 'when search parameters are empty' do
@@ -30,9 +30,9 @@ describe 'Consolidated Envirotech API V1', type: :request do
     end
   end
 
-  describe 'GET /envirotech/issues/search.json' do
+  describe 'GET /v1/envirotech/issues/search' do
     let(:params) { { size: 100 } }
-    before { get '/envirotech/issues/search', params }
+    before { get '/v1/envirotech/issues/search', params }
     subject { response }
 
     context 'when search parameters are empty' do
@@ -57,9 +57,9 @@ describe 'Consolidated Envirotech API V1', type: :request do
     end
   end
 
-  describe 'GET /envirotech/regulations/search.json' do
+  describe 'GET /v1/envirotech/regulations/search' do
     let(:params) { { size: 100 } }
-    before { get '/envirotech/regulations/search', params }
+    before { get '/v1/envirotech/regulations/search', params }
     subject { response }
 
     context 'when search parameters are empty' do
@@ -84,9 +84,9 @@ describe 'Consolidated Envirotech API V1', type: :request do
     end
   end
 
-  describe 'GET /envirotech/providers/search.json' do
+  describe 'GET /v1/envirotech/providers/search' do
     let(:params) { { size: 100 } }
-    before { get '/envirotech/providers/search', params }
+    before { get '/v1/envirotech/providers/search', params }
     subject { response }
 
     context 'when search parameters are empty' do
@@ -111,9 +111,9 @@ describe 'Consolidated Envirotech API V1', type: :request do
     end
   end
 
-  describe 'GET /envirotech/analysis_links/search.json' do
+  describe 'GET /v1/envirotech/analysis_links/search' do
     let(:params) { { size: 100 } }
-    before { get '/envirotech/analysis_links/search', params }
+    before { get '/v1/envirotech/analysis_links/search', params }
     subject { response }
 
     context 'when search parameters are empty' do
@@ -146,9 +146,9 @@ describe 'Consolidated Envirotech API V1', type: :request do
     end
   end
 
-  describe 'GET /envirotech/background_links/search.json' do
+  describe 'GET /v1/envirotech/background_links/search' do
     let(:params) { { size: 100 } }
-    before { get '/envirotech/background_links/search', params }
+    before { get '/v1/envirotech/background_links/search', params }
     subject { response }
 
     context 'when search parameters are empty' do
@@ -181,9 +181,9 @@ describe 'Consolidated Envirotech API V1', type: :request do
     end
   end
 
-  describe 'GET /envirotech/provider_solutions/search.json' do
+  describe 'GET /v1/envirotech/provider_solutions/search' do
     let(:params) { { size: 100 } }
-    before { get '/envirotech/provider_solutions/search', params }
+    before { get '/v1/envirotech/provider_solutions/search', params }
     subject { response }
 
     context 'when search parameters are empty' do

--- a/spec/api/v1/fbopen_leads_spec.rb
+++ b/spec/api/v1/fbopen_leads_spec.rb
@@ -7,12 +7,12 @@ describe 'Fbopen Leads API V1', type: :request do
       "#{Rails.root}/spec/fixtures/trade_leads/fbopen/patch_source_short_input").import
   end
 
-  let(:search_path) { '/fbopen_leads/search' }
+  let(:search_path) { '/v1/fbopen_leads/search' }
   let(:expected_results) do
     JSON.parse(open("#{File.dirname(__FILE__)}/trade_leads/fbopen/results.json").read)
   end
 
-  describe 'GET /fbopen_leads/search.json' do
+  describe 'GET /v1/fbopen_leads/search' do
     context 'when search parameters are empty' do
       before { get search_path, size: 100 }
       subject { response }

--- a/spec/api/v1/ita_office_locations_spec.rb
+++ b/spec/api/v1/ita_office_locations_spec.rb
@@ -9,10 +9,10 @@ describe 'ITA Office Locations API V1', type: :request do
 
   let(:expected_results) { JSON.parse open("#{File.dirname(__FILE__)}/ita_office_locations/results.json").read }
 
-  describe 'GET /ita_office_locations/search.json' do
+  describe 'GET /v1/ita_office_locations/search' do
     context 'when q is specified' do
       let(:params) { { q: 'san jose' } }
-      before { get '/ita_office_locations/search', params }
+      before { get '/v1/ita_office_locations/search', params }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -29,7 +29,7 @@ describe 'ITA Office Locations API V1', type: :request do
     end
 
     context 'when country is specified' do
-      before { get '/ita_office_locations/search', q: 'saN Jose', country: 'Cr' }
+      before { get '/v1/ita_office_locations/search', q: 'saN Jose', country: 'Cr' }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -44,7 +44,7 @@ describe 'ITA Office Locations API V1', type: :request do
     end
 
     context 'when USA and state is specified' do
-      before { get '/ita_office_locations/search', q: 'san jose', country: 'US', state: 'CA' }
+      before { get '/v1/ita_office_locations/search', q: 'san jose', country: 'US', state: 'CA' }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -59,7 +59,7 @@ describe 'ITA Office Locations API V1', type: :request do
     end
 
     context 'when just US state is specified' do
-      before { get '/ita_office_locations/search', q: 'san jose', state: 'CA' }
+      before { get '/v1/ita_office_locations/search', q: 'san jose', state: 'CA' }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -74,7 +74,7 @@ describe 'ITA Office Locations API V1', type: :request do
     end
 
     context 'when country and city are specified' do
-      before { get '/ita_office_locations/search', country: 'cr', city: 'san jose' }
+      before { get '/v1/ita_office_locations/search', country: 'cr', city: 'san jose' }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -90,7 +90,7 @@ describe 'ITA Office Locations API V1', type: :request do
 
     context 'when multiple countries are specified' do
       let(:params) { { country: 'RU,CN' } }
-      before { get '/ita_office_locations/search', params }
+      before { get '/v1/ita_office_locations/search', params }
       subject { response }
 
       it_behaves_like 'a successful search request'

--- a/spec/api/v1/market_research_library/search_spec.rb
+++ b/spec/api/v1/market_research_library/search_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe 'Market Researches API V1', type: :request do
   include_context 'MarketResearch data'
 
-  let(:search_path) { '/market_research_library/search' }
+  let(:search_path) { '/v1/market_research_library/search' }
   let(:expected_results) { JSON.parse open("#{File.dirname(__FILE__)}/results.json").read }
 
-  describe 'GET /market_research_library/search.json' do
+  describe 'GET /v1/market_research_library/search' do
     context 'when search parameters are empty' do
       before { get search_path, {} }
       subject { response }

--- a/spec/api/v1/parature_faq_spec.rb
+++ b/spec/api/v1/parature_faq_spec.rb
@@ -7,10 +7,10 @@ describe 'Parature Faq API V1', type: :request do
                         "#{Rails.root}/spec/fixtures/parature_faqs/folders.xml").import
   end
 
-  let(:search_path) { '/ita_faqs/search' }
+  let(:search_path) { '/v1/ita_faqs/search' }
   let(:expected_results) { YAML.load_file("#{File.dirname(__FILE__)}/parature_faqs/results.yaml") }
 
-  describe 'GET /ita_faqs/search.json' do
+  describe 'GET /v1/ita_faqs/search' do
     context 'when search parameters are empty' do
       before { get search_path, size: 50 }
       subject { response }

--- a/spec/api/v1/screening_lists/consolidated_spec.rb
+++ b/spec/api/v1/screening_lists/consolidated_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Consolidated Screening List API V1', type: :request do
   include_context 'all CSL fixture data'
 
-  describe 'GET /consolidated_screening_list/search' do
+  describe 'GET /v1/consolidated_screening_list/search' do
     let(:params) { { size: 100 } }
-    before { get '/consolidated_screening_list/search', params }
+    before { get '/v1/consolidated_screening_list/search', params }
 
     context 'when search parameters are empty' do
       subject { response }
@@ -271,8 +271,8 @@ describe 'Consolidated Screening List API V1', type: :request do
       end
     end
   end
-  describe 'GET /consolidated_screening_list/search.csv' do
-    before { get '/consolidated_screening_list/search.csv' }
+  describe 'GET /v1/consolidated_screening_list/search.csv' do
+    before { get '/v1/consolidated_screening_list/search.csv' }
     it 'is a CSV' do
       expect(response.status).to eq(200)
       expect(response.content_type.symbol).to eq(:csv)

--- a/spec/api/v1/screening_lists/dpl_spec.rb
+++ b/spec/api/v1/screening_lists/dpl_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'BIS Denied Persons API V1', type: :request do
   include_context 'ScreeningList::Dpl data'
 
-  describe 'GET /consolidated_screening_list/dpl/search' do
+  describe 'GET /v1/consolidated_screening_list/dpl/search' do
     let(:params) { {} }
-    before { get '/consolidated_screening_list/dpl/search', params }
+    before { get '/v1/consolidated_screening_list/dpl/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/screening_lists/dtc_spec.rb
+++ b/spec/api/v1/screening_lists/dtc_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'DDTC ITAR Debarred Parties API V1', type: :request do
   include_context 'ScreeningList::Dtc data'
 
-  describe 'GET /consolidated_screening_list/dtc/search' do
+  describe 'GET /v1/consolidated_screening_list/dtc/search' do
     let(:params) { {} }
-    before { get '/consolidated_screening_list/dtc/search', params }
+    before { get '/v1/consolidated_screening_list/dtc/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/screening_lists/el_spec.rb
+++ b/spec/api/v1/screening_lists/el_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'BIS Entities API V1', type: :request do
   include_context 'ScreeningList::El data'
 
-  describe 'GET /consolidated_screening_list/el/search' do
+  describe 'GET /v1/consolidated_screening_list/el/search' do
     let(:params) { {} }
-    before { get '/consolidated_screening_list/el/search', params }
+    before { get '/v1/consolidated_screening_list/el/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/screening_lists/fse_spec.rb
+++ b/spec/api/v1/screening_lists/fse_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'BISN Foreign Sanctions Evaders API V1', type: :request do
   include_context 'ScreeningList::Fse data'
 
-  describe 'GET /consolidated_screening_list/fse/search' do
+  describe 'GET /v1/consolidated_screening_list/fse/search' do
     let(:params) { {} }
-    before { get '/consolidated_screening_list/fse/search', params }
+    before { get '/v1/consolidated_screening_list/fse/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/screening_lists/isn_spec.rb
+++ b/spec/api/v1/screening_lists/isn_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'BISN Nonproliferation Sanctions API V1', type: :request do
   include_context 'ScreeningList::Isn data'
 
-  describe 'GET /consolidated_screening_list/isn/search' do
+  describe 'GET /v1/consolidated_screening_list/isn/search' do
     let(:params) { {} }
-    before { get '/consolidated_screening_list/isn/search', params }
+    before { get '/v1/consolidated_screening_list/isn/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/screening_lists/plc_spec.rb
+++ b/spec/api/v1/screening_lists/plc_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Palestinian Legislative Council List API V1', type: :request do
   include_context 'ScreeningList::Plc data'
 
-  describe 'GET /consolidated_screening_list/plc/search' do
+  describe 'GET /v1/consolidated_screening_list/plc/search' do
     let(:params) { {} }
-    before { get '/consolidated_screening_list/plc/search', params }
+    before { get '/v1/consolidated_screening_list/plc/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/screening_lists/sdn_spec.rb
+++ b/spec/api/v1/screening_lists/sdn_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'OFAC Specially Designated Nationals API V1', type: :request do
   include_context 'ScreeningList::Sdn data'
 
-  describe 'GET /consolidated_screening_list/sdn/search' do
+  describe 'GET /v1/consolidated_screening_list/sdn/search' do
     let(:params) { {} }
-    before { get '/consolidated_screening_list/sdn/search', params }
+    before { get '/v1/consolidated_screening_list/sdn/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/screening_lists/ssi_spec.rb
+++ b/spec/api/v1/screening_lists/ssi_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Sectoral Sanctions Identifications List API V1', type: :request do
   include_context 'ScreeningList::Ssi data'
 
-  describe 'GET /consolidated_screening_list/ssi/search' do
+  describe 'GET /v1/consolidated_screening_list/ssi/search' do
     let(:params) { {} }
-    before { get '/consolidated_screening_list/ssi/search', params }
+    before { get '/v1/consolidated_screening_list/ssi/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/screening_lists/uvl_spec.rb
+++ b/spec/api/v1/screening_lists/uvl_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'BIS Unverified Parties API V1', type: :request do
   include_context 'ScreeningList::Uvl data'
 
-  describe 'GET /consolidated_screening_list/uvl/search' do
+  describe 'GET /v1/consolidated_screening_list/uvl/search' do
     let(:params) { { size: 100 } }
-    before { get '/consolidated_screening_list/uvl/search', params }
+    before { get '/v1/consolidated_screening_list/uvl/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/state_trade_leads_spec.rb
+++ b/spec/api/v1/state_trade_leads_spec.rb
@@ -8,9 +8,9 @@ describe 'State Trade Leads API V1', type: :request do
   end
   let(:expected_results) { JSON.parse(open("#{File.dirname(__FILE__)}/trade_leads/state/results.json").read) }
 
-  describe 'GET /state_trade_leads/search' do
+  describe 'GET /v1/state_trade_leads/search' do
     let(:params) { {} }
-    before { get '/state_trade_leads/search', params }
+    before { get '/v1/state_trade_leads/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/australia_spec.rb
+++ b/spec/api/v1/tariff_rates/australia_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Australia Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Australia data'
 
-  describe 'GET /tariff_rates/search?sources=AU' do
+  describe 'GET /v1/tariff_rates/search?sources=AU' do
     let(:params) { { sources: 'au' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/bahrain_spec.rb
+++ b/spec/api/v1/tariff_rates/bahrain_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Bahrain Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Bahrain data'
 
-  describe 'GET /tariff_rates/search?sources=BH' do
+  describe 'GET /v1/tariff_rates/search?sources=BH' do
     let(:params) { { sources: 'bh' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/chile_spec.rb
+++ b/spec/api/v1/tariff_rates/chile_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Chile Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Chile data'
 
-  describe 'GET /tariff_rates/search?sources=CL' do
+  describe 'GET /v1/tariff_rates/search?sources=CL' do
     let(:params) { { sources: 'cl' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/colombia_spec.rb
+++ b/spec/api/v1/tariff_rates/colombia_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Colombia Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Colombia data'
 
-  describe 'GET /tariff_rates/search?sources=CO' do
+  describe 'GET /v1/tariff_rates/search?sources=CO' do
     let(:params) { { sources: 'co' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/consolidated_spec.rb
+++ b/spec/api/v1/tariff_rates/consolidated_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Consolidated Tariff Rates API V1', type: :request do
   include_context 'all Tariff Rates fixture data'
 
-  describe 'GET /tariff_rates/search' do
+  describe 'GET /v1/tariff_rates/search' do
     let(:params) { { size: 100 } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/costa_rica_spec.rb
+++ b/spec/api/v1/tariff_rates/costa_rica_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Costa Rica Tariff Rates API V1', type: :request do
   include_context 'TariffRate::CostaRica data'
 
-  describe 'GET /tariff_rates/search?sources=CR' do
+  describe 'GET /v1/tariff_rates/search?sources=CR' do
     let(:params) { { sources: 'cr' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/dominican_republic_spec.rb
+++ b/spec/api/v1/tariff_rates/dominican_republic_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA DominicanRepublic Tariff Rates API V1', type: :request do
   include_context 'TariffRate::DominicanRepublic data'
 
-  describe 'GET /tariff_rates/search?sources=DO' do
+  describe 'GET /v1/tariff_rates/search?sources=DO' do
     let(:params) { { sources: 'do' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/el_salvador_spec.rb
+++ b/spec/api/v1/tariff_rates/el_salvador_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA El Salvador Tariff Rates API V1', type: :request do
   include_context 'TariffRate::ElSalvador data'
 
-  describe 'GET /tariff_rates/search?sources=SV' do
+  describe 'GET /v1/tariff_rates/search?sources=SV' do
     let(:params) { { sources: 'sv' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/guatemala_spec.rb
+++ b/spec/api/v1/tariff_rates/guatemala_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Guatemala Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Guatemala data'
 
-  describe 'GET /tariff_rates/search?sources=GT' do
+  describe 'GET /v1/tariff_rates/search?sources=GT' do
     let(:params) { { sources: 'gt' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/honduras_spec.rb
+++ b/spec/api/v1/tariff_rates/honduras_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Honduras Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Honduras data'
 
-  describe 'GET /tariff_rates/search?sources=HN' do
+  describe 'GET /v1/tariff_rates/search?sources=HN' do
     let(:params) { { sources: 'hn' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/morocco_spec.rb
+++ b/spec/api/v1/tariff_rates/morocco_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Morocco Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Morocco data'
 
-  describe 'GET /tariff_rates/search?sources=MA' do
+  describe 'GET /v1/tariff_rates/search?sources=MA' do
     let(:params) { { sources: 'ma' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/nicaragua_spec.rb
+++ b/spec/api/v1/tariff_rates/nicaragua_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Nicaragua Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Nicaragua data'
 
-  describe 'GET /tariff_rates/search?sources=NI' do
+  describe 'GET /v1/tariff_rates/search?sources=NI' do
     let(:params) { { sources: 'ni' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/oman_spec.rb
+++ b/spec/api/v1/tariff_rates/oman_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Oman Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Oman data'
 
-  describe 'GET /tariff_rates/search?sources=OM' do
+  describe 'GET /v1/tariff_rates/search?sources=OM' do
     let(:params) { { sources: 'om' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/panama_spec.rb
+++ b/spec/api/v1/tariff_rates/panama_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Panama Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Panama data'
 
-  describe 'GET /tariff_rates/search?sources=PA' do
+  describe 'GET /v1/tariff_rates/search?sources=PA' do
     let(:params) { { sources: 'pa' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/peru_spec.rb
+++ b/spec/api/v1/tariff_rates/peru_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Peru Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Peru data'
 
-  describe 'GET /tariff_rates/search?sources=PE' do
+  describe 'GET /v1/tariff_rates/search?sources=PE' do
     let(:params) { { sources: 'pe' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/singapore_spec.rb
+++ b/spec/api/v1/tariff_rates/singapore_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA Singapore Tariff Rates API V1', type: :request do
   include_context 'TariffRate::Singapore data'
 
-  describe 'GET /tariff_rates/search?sources=SG' do
+  describe 'GET /v1/tariff_rates/search?sources=SG' do
     let(:params) { { sources: 'sg' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/tariff_rates/south_korea_spec.rb
+++ b/spec/api/v1/tariff_rates/south_korea_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'FTA South Korea Tariff Rates API V1', type: :request do
   include_context 'TariffRate::SouthKorea data'
 
-  describe 'GET /tariff_rates/search?sources=KR' do
+  describe 'GET /v1/tariff_rates/search?sources=KR' do
     let(:params) { { sources: 'kr' } }
-    before { get '/tariff_rates/search', params }
+    before { get '/v1/tariff_rates/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/api/v1/trade_articles_spec.rb
+++ b/spec/api/v1/trade_articles_spec.rb
@@ -9,8 +9,8 @@ describe 'Trade Articles API V1', type: :request do
 
   let(:expected_results) { JSON.parse open("#{File.dirname(__FILE__)}/trade_articles/results.json").read }
 
-  describe 'GET /trade_articles/search.json' do
-    before { get '/trade_articles/search', params }
+  describe 'GET /v1/trade_articles/search' do
+    before { get '/v1/trade_articles/search', params }
 
     context 'when all params are specified' do
       let(:params) do

--- a/spec/api/v1/trade_events/consolidated_spec.rb
+++ b/spec/api/v1/trade_events/consolidated_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Consolidated Trade Events API V1', type: :request do
   include_context 'all Trade Events fixture data'
 
-  describe 'GET /trade_events/search' do
+  describe 'GET /v1/trade_events/search' do
     let(:params) { { size: 100 } }
-    before { get '/trade_events/search', params }
+    before { get '/v1/trade_events/search', params }
     subject { response }
 
     context 'when search parameters are empty' do

--- a/spec/api/v1/trade_events/dl_spec.rb
+++ b/spec/api/v1/trade_events/dl_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'DL Trade Events API V1', type: :request do
   include_context 'TradeEvent::Dl data'
 
-  describe 'GET /trade_events/dl/search' do
+  describe 'GET /v1/trade_events/dl/search' do
     let(:params) { { size: 100 } }
-    before { get '/trade_events/dl/search', params }
+    before { get '/v1/trade_events/dl/search', params }
     subject { response }
 
     context 'when search parameters are empty' do

--- a/spec/api/v1/trade_events/exim_spec.rb
+++ b/spec/api/v1/trade_events/exim_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'EXIM Trade Events API V1', type: :request do
   include_context 'TradeEvent::Exim data'
 
-  describe 'GET /trade_events/exim/search' do
+  describe 'GET /v1/trade_events/exim/search' do
     let(:params) { { size: 100 } }
-    before { get '/trade_events/exim/search', params }
+    before { get '/v1/trade_events/exim/search', params }
     subject { response }
 
     context 'when search parameters are empty' do

--- a/spec/api/v1/trade_events/ita_spec.rb
+++ b/spec/api/v1/trade_events/ita_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'ITA Trade Events API V1', type: :request do
   include_context 'TradeEvent::Ita data'
 
-  describe 'GET /trade_events/ita/search' do
+  describe 'GET /v1/trade_events/ita/search' do
     let(:params) { {} }
-    before { get '/trade_events/ita/search', params }
+    before { get '/v1/trade_events/ita/search', params }
     subject { response }
 
     context 'when search parameters are empty' do

--- a/spec/api/v1/trade_events/sba_spec.rb
+++ b/spec/api/v1/trade_events/sba_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'SBA Trade Events API V1', type: :request do
   include_context 'TradeEvent::Sba data'
 
-  describe 'GET /trade_events/sba/search' do
+  describe 'GET /v1/trade_events/sba/search' do
     let(:params) { { size: 100 } }
-    before { get '/trade_events/sba/search', params }
+    before { get '/v1/trade_events/sba/search', params }
     subject { response }
 
     context 'when search parameters are empty' do

--- a/spec/api/v1/trade_events/ustda_spec.rb
+++ b/spec/api/v1/trade_events/ustda_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Trade Events API V1', type: :request do
   include_context 'TradeEvent::Ustda data'
 
-  describe 'GET /trade_events/ustda/search.json' do
+  describe 'GET /v1/trade_events/ustda/search.json' do
     let(:params) { { size: 100 } }
-    before { get '/trade_events/ustda/search', params }
+    before { get '/v1/trade_events/ustda/search', params }
     subject { response }
 
     context 'when search parameters are empty' do

--- a/spec/api/v1/trade_leads_spec.rb
+++ b/spec/api/v1/trade_leads_spec.rb
@@ -16,9 +16,9 @@ describe 'Trade Leads API V1', type: :request do
 
   let(:expected_results) { JSON.parse Rails.root.join("#{File.dirname(__FILE__)}/trade_leads/expected_results.json").read }
 
-  describe 'GET /trade_leads/search.json' do
+  describe 'GET /v1/trade_leads/search.json' do
     context 'when search parameters are empty' do
-      before { get '/trade_leads/search' }
+      before { get '/v1/trade_leads/search' }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -34,7 +34,7 @@ describe 'Trade Leads API V1', type: :request do
     end
 
     context 'when size is specified' do
-      before { get '/trade_leads/search', size: 100 }
+      before { get '/v1/trade_leads/search', size: 100 }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -51,7 +51,7 @@ describe 'Trade Leads API V1', type: :request do
 
     context 'when countries is populated' do
       let(:params) { { countries: 'CA' } }
-      before { get '/trade_leads/search', params }
+      before { get '/v1/trade_leads/search', params }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -73,7 +73,7 @@ describe 'Trade Leads API V1', type: :request do
 
     context 'when industries is populated' do
       let(:params) { { industries: 'dental' } }
-      before { get '/trade_leads/search', params }
+      before { get '/v1/trade_leads/search', params }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -91,7 +91,7 @@ describe 'Trade Leads API V1', type: :request do
 
     context 'when q matches a title' do
       let(:params) { { q: 'physician service' } }
-      before { get '/trade_leads/search', params }
+      before { get '/v1/trade_leads/search', params }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -108,7 +108,7 @@ describe 'Trade Leads API V1', type: :request do
     end
 
     context 'when q matches a description' do
-      before { get '/trade_leads/search', q: 'ambulatory' }
+      before { get '/v1/trade_leads/search', q: 'ambulatory' }
       subject { response }
 
       it_behaves_like 'a successful search request'

--- a/spec/api/v1/uk_trade_leads_spec.rb
+++ b/spec/api/v1/uk_trade_leads_spec.rb
@@ -11,9 +11,9 @@ describe 'UK Trade Leads API V1', type: :request do
                symbolize_names: true)
   end
 
-  describe 'GET /uk_trade_leads/search' do
+  describe 'GET /v1/uk_trade_leads/search' do
     let(:params) { {} }
-    before { get '/uk_trade_leads/search', params }
+    before { get '/v1/uk_trade_leads/search', params }
 
     context 'when search parameters are empty' do
       subject { response }

--- a/spec/routing/api_spec.rb
+++ b/spec/routing/api_spec.rb
@@ -13,7 +13,7 @@ describe 'routes for Trade Events' do
 
     it 'route to the first API trade_events version' do
       expect(get: request_path)
-        .to route_to(controller: 'api/v1/trade_events/consolidated', action: 'search', format: :json)
+        .to route_to(controller: 'api/v2/trade_events/consolidated', action: 'search', format: :json)
     end
   end
 

--- a/spec/support/empty_results_behavior.rb
+++ b/spec/support/empty_results_behavior.rb
@@ -7,7 +7,7 @@ shared_examples "an empty result when a query doesn't match any documents" do |o
   # Allows this shared example to support queries that involves extra parameters
   # ie.: a specific source for tariff rates
   original_params ||= {}
-  let(:params) { original_params.merge({ q: 'asdzxcasd' }) }
+  let(:params) { original_params.merge(q: 'asdzxcasd') }
   it_behaves_like 'an empty result'
 end
 


### PR DESCRIPTION
@jamesisaacs this merely switches the default version. It doesn't disable v1 or remove any v1 code. I think both those changes should happen later (and at separate times).