### PR TITLE
Update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 bundler_args: --without development staging production
 language: ruby
-rvm:
-  - 2.1.0
-before_install:
-  - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.2.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.2.1.deb && true
-  - sudo service elasticsearch start
+sudo: false
+services:
+  - elasticsearch
 
 addons:
  code_climate:


### PR DESCRIPTION
- Remove rvm section so Travis will use the ruby specified in .ruby-version. Currently .ruby-version is set to 2.1.3 but Travis is set to 2.1.0, so this will bring those in line
- Set sudo false to tell Travis it's OK to use their newer Docker-based infrastructure
- Use recent (and probably latest) version of elasticsearch for testing