### PR TITLE
Carlos/last imported everywhere

### DIFF
--- a/app/importers/concerns/importable.rb
+++ b/app/importers/concerns/importable.rb
@@ -20,6 +20,7 @@ module Importable
       start_time = Time.now if can_purge_old?
       super
       model_class.purge_old(start_time) if can_purge_old?
+      model_class.touch_metadata
       Rails.logger.info "#{self.class.name}: import finished."
     end
   end

--- a/app/models/business_service_provider.rb
+++ b/app/models/business_service_provider.rb
@@ -25,7 +25,7 @@ class BusinessServiceProvider
         category:            { type: 'string', analyzer: 'keyword_asciifolding_lowercase' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'ITA',

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -8,6 +8,25 @@ module Indexable
   included do
     class << self
       attr_accessor :mappings, :settings, :source
+      def metadata_mappings
+        {
+          metadata: {
+            properties: {
+              last_imported: {
+                type:   'date',
+                format: 'dateOptionalTime',
+              },
+              last_updated:  {
+                type:   'date',
+                format: 'dateOptionalTime',
+              },
+              version:       {
+                type: 'string',
+              },
+            },
+          },
+        }
+      end
     end
 
     # If the model class doesn't define the source full_name,
@@ -114,7 +133,7 @@ module Indexable
         },
       }
 
-      ES.client.delete_by_query(index: index_name, body: body)
+      ES.client.delete_by_query(index: index_name, type: index_type, body: body)
     end
 
     def can_purge_old?

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -13,12 +13,10 @@ module Indexable
           metadata: {
             properties: {
               last_imported: {
-                type:   'date',
-                format: 'dateOptionalTime',
+                type: 'string',
               },
               last_updated:  {
-                type:   'date',
-                format: 'dateOptionalTime',
+                type: 'string',
               },
               version:       {
                 type: 'string',
@@ -84,7 +82,7 @@ module Indexable
     end
 
     # If any field is not present, we initialize it with those values.
-    EMPTY_METADATA = { version: '', last_updated: '0000-01-01T00:00:00Z', last_imported: '0000-01-01T00:00:00Z' }
+    EMPTY_METADATA = { version: '', last_updated: '', last_imported: '' }
 
     def stored_metadata
       stored = ES.client.get(

--- a/app/models/country_commercial_guide.rb
+++ b/app/models/country_commercial_guide.rb
@@ -25,7 +25,7 @@ class CountryCommercialGuide
         section_url:   { type: 'string' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'Country Commercial Guide',

--- a/app/models/country_fact_sheet.rb
+++ b/app/models/country_fact_sheet.rb
@@ -34,7 +34,7 @@ class CountryFactSheet
         published_date: { type: 'date', format: 'YYYY-MM-dd' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'U.S. Department of State',

--- a/app/models/eccn.rb
+++ b/app/models/eccn.rb
@@ -24,7 +24,7 @@ class Eccn
         url2:        { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'Eccn',

--- a/app/models/envirotech/mappable.rb
+++ b/app/models/envirotech/mappable.rb
@@ -71,7 +71,7 @@ module Envirotech
             regulation_ids:      { type: 'integer' },
           },
         },
-      }.freeze
+      }.merge(klass.metadata_mappings).freeze
 
       klass.class_eval do
         class << self

--- a/app/models/ita_office_location.rb
+++ b/app/models/ita_office_location.rb
@@ -44,7 +44,7 @@ class ItaOfficeLocation
         city:        { type: 'string', analyzer: 'location_name_analyzer' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'ITA',

--- a/app/models/ita_taxonomy.rb
+++ b/app/models/ita_taxonomy.rb
@@ -26,7 +26,7 @@ class ItaTaxonomy
         parent_names: { type: 'string', analyzer: 'lowercase_keyword_analyzer' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'ITA',

--- a/app/models/ita_zip_code.rb
+++ b/app/models/ita_zip_code.rb
@@ -32,7 +32,7 @@ class ItaZipCode
         address:           { type: 'string' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'ITA',

--- a/app/models/market_research.rb
+++ b/app/models/market_research.rb
@@ -32,7 +32,7 @@ class MarketResearch
         },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'ITA',

--- a/app/models/parature_faq.rb
+++ b/app/models/parature_faq.rb
@@ -20,7 +20,7 @@ class ParatureFaq
         country:     { type: 'string' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'ITA',

--- a/app/models/screening_list/mappable.rb
+++ b/app/models/screening_list/mappable.rb
@@ -85,7 +85,7 @@ module ScreeningList
             entity_number:              { type: 'integer' },
           },
         },
-      }.freeze
+      }.merge(klass.metadata_mappings).freeze
 
       klass.class_eval do
         class << self

--- a/app/models/sharepoint_trade_article.rb
+++ b/app/models/sharepoint_trade_article.rb
@@ -44,7 +44,7 @@ class SharepointTradeArticle
         url_xml_source:           { type: 'string' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'ITA',

--- a/app/models/tariff_rate/mappable.rb
+++ b/app/models/tariff_rate/mappable.rb
@@ -35,7 +35,7 @@ module TariffRate
             source:                      { type: 'string', analyzer: 'keyword' },
           },
         },
-      }.freeze
+      }.merge(klass.metadata_mappings).freeze
 
       klass.class_eval do
         class << self

--- a/app/models/trade_article.rb
+++ b/app/models/trade_article.rb
@@ -13,7 +13,7 @@ class TradeArticle
         update_date: { type: 'date', format: 'YYYY-MM-dd' },
       },
     },
-  }.freeze
+  }.merge(metadata_mappings).freeze
 
   self.source = {
     full_name: 'ITA',

--- a/app/models/trade_event/mappable.rb
+++ b/app/models/trade_event/mappable.rb
@@ -37,7 +37,7 @@ module TradeEvent
             source:             { type: 'string', analyzer: 'keyword' },
           },
         },
-      }.freeze
+      }.merge(klass.metadata_mappings).freeze
 
       klass.class_eval do
         class << self

--- a/app/models/trade_lead/mappable.rb
+++ b/app/models/trade_lead/mappable.rb
@@ -40,7 +40,7 @@ module TradeLead
             categories:               { type: 'string', analyzer: 'keyword' },
           },
         },
-      }.freeze
+      }.merge(klass.metadata_mappings).freeze
 
       klass.class_eval do
         class << self

--- a/spec/importers/concerns/importable_spec.rb
+++ b/spec/importers/concerns/importable_spec.rb
@@ -11,7 +11,7 @@ describe Importable do
             store:   true,
           },
         },
-      }
+      }.merge(metadata_mappings).freeze
     end
 
     class MockData
@@ -152,14 +152,14 @@ describe Importable do
   end
   describe '#import' do
     before do
-      Mock.update_metadata('', '0000-01-01T00:00:00Z')
+      Mock.update_metadata('', '')
     end
     it 'stores the last_imported time' do
       expect {
         MockData.new([{ id: 3, content: 'ping pong'}]).import
       }.to change {
         Mock.stored_metadata[:last_imported]
-      }.from('0000-01-01T00:00:00Z')
+      }.from('')
 
       last_imported_time = DateTime.parse(Mock.stored_metadata[:last_imported])
       expect(last_imported_time.to_time).to be_within(60.seconds).of(Time.now)

--- a/spec/importers/concerns/importable_spec.rb
+++ b/spec/importers/concerns/importable_spec.rb
@@ -150,4 +150,19 @@ describe Importable do
       Mock.search_for({})[:hits].map { |h| h[:_source].deep_symbolize_keys }
     end
   end
+  describe '#import' do
+    before do
+      Mock.update_metadata('', '0000-01-01T00:00:00Z')
+    end
+    it 'stores the last_imported time' do
+      expect {
+        MockData.new([{ id: 3, content: 'ping pong'}]).import
+      }.to change {
+        Mock.stored_metadata[:last_imported]
+      }.from('0000-01-01T00:00:00Z')
+
+      last_imported_time = DateTime.parse(Mock.stored_metadata[:last_imported])
+      expect(last_imported_time.to_time).to be_within(60.seconds).of(Time.now)
+    end
+  end
 end

--- a/spec/importers/concerns/versionable_resource_spec.rb
+++ b/spec/importers/concerns/versionable_resource_spec.rb
@@ -46,7 +46,7 @@ describe VersionableResource do
 
   describe '#import' do
     it 'stores the time of import' do
-      expect(Mock.stored_metadata).to eq({})
+      expect(Mock.stored_metadata[:version]).to eq('')
       MockData.new([{ id: 1, content: 'foo' }]).import
       expect(Mock.stored_metadata[:last_updated]).to_not be_nil
       expect(Mock.stored_metadata[:last_imported]).to_not be_nil
@@ -54,27 +54,15 @@ describe VersionableResource do
 
     context 'when source is unchanged' do
       before do
-        expect(Mock.stored_metadata).to eq({})
+        expect(Mock.stored_metadata[:version]).to eq('')
         MockData.new([{ id: 1, content: 'foo' }]).import
         Mock.update_metadata(Mock.stored_metadata[:version], '2000-01-01')
         MockData.new([{ id: 1, content: 'foo' }]).import
       end
       it 'updates only the time of import when source is unchanged' do
         expect(Mock.stored_metadata[:last_updated]).to eq('2000-01-01')
-        expect(Mock.stored_metadata[:last_imported]).to_not eq('2000-01-01')
         expect(Mock.stored_metadata[:version]).to eq('29cb2c0fe72b5d841236ddf88e22371a58649717')
-      end
-    end
-
-    context 'when old last_updated format is present in metadata' do
-      before do
-        expect(Mock.stored_metadata).to eq({})
-        Mock._update_metadata(time: 'quite some time ago')
-      end
-      subject { Mock.stored_metadata }
-      it 'renames the "time" field to "last_updated"' do
-        expect(subject[:time]).to be_nil
-        expect(subject[:last_updated]).to eq('quite some time ago')
+        expect(Mock.stored_metadata[:last_imported]).to_not eq('2000-01-01')
       end
     end
 

--- a/spec/models/concerns/indexable_spec.rb
+++ b/spec/models/concerns/indexable_spec.rb
@@ -120,8 +120,12 @@ describe Indexable do
 
   describe '.create_index' do
     include_context 'a working Mock model class'
-    it 'creates metadata with the last_imported time' do
-      Mock.recreate_index
+    before { Mock.recreate_index }
+    it 'creates metadata' do
+      m = Mock.stored_metadata
+      expect(m.keys).to match_array %i(last_imported last_updated version)
+    end
+    it 'sets last_imported to the current time' do
       last_imported_time = DateTime.parse(Mock.stored_metadata[:last_imported])
       expect(last_imported_time.to_time).to be_within(60.seconds).of(Time.now)
     end

--- a/spec/models/concerns/indexable_spec.rb
+++ b/spec/models/concerns/indexable_spec.rb
@@ -80,7 +80,7 @@ describe Indexable do
        { 'title' => 'bar' }]
     end
 
-    let(:search) { ES.client.search(index: Mock.index_name) }
+    let(:search) { ES.client.search(index: Mock.index_name, type: Mock.index_type) }
 
     subject(:total) { search['hits']['total'] }
     subject(:docs_retrieved) do
@@ -116,5 +116,14 @@ describe Indexable do
     include_context 'a working Mock model class'
     subject { Mock.importer_class }
     it { is_expected.to eq(MockData) }
+  end
+
+  describe '.create_index' do
+    include_context 'a working Mock model class'
+    it 'creates metadata with the last_imported time' do
+      Mock.recreate_index
+      last_imported_time = DateTime.parse(Mock.stored_metadata[:last_imported])
+      expect(last_imported_time.to_time).to be_within(60.seconds).of(Time.now)
+    end
   end
 end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -56,7 +56,7 @@ describe Searchable do
   end
 
   before(:each) do
-    MockModel.update_metadata(9989, 'a few minutes ago')
+    MockModel.update_metadata(9989, '2001-01-01T01:01:01Z')
   end
 
   after(:all) do
@@ -75,16 +75,16 @@ describe Searchable do
     describe '#touch_metadata' do
       subject { MockModel.stored_metadata }
       it 'updates only the import_time field' do
-        MockModel.touch_metadata('just now')
-        expect(subject).to eq(version: 9989, last_updated: 'a few minutes ago', last_imported: 'just now')
+        MockModel.touch_metadata('3000-03-03T03:03:03Z')
+        expect(subject).to eq(version: 9989, last_updated: '2001-01-01T01:01:01Z', last_imported: '3000-03-03T03:03:03Z')
       end
     end
 
     describe '#update_metadata' do
       subject { MockModel.stored_metadata }
       it 'updates all fields' do
-        MockModel.update_metadata(4321, 'NOW!')
-        expect(subject).to eq(version: 4321, last_updated: 'NOW!', last_imported: 'NOW!')
+        MockModel.update_metadata(4321, '4000-04-04T04:04:04Z')
+        expect(subject).to eq(version: 4321, last_updated: '4000-04-04T04:04:04Z', last_imported: '4000-04-04T04:04:04Z')
       end
     end
   end
@@ -108,7 +108,7 @@ describe Searchable do
 
     it 'response includes metadata' do
       expect(subject.keys).to include(:sources_used)
-      expect(subject[:sources_used]).to eq([{ source_last_updated: 'a few minutes ago', last_imported: 'a few minutes ago', source: 'A mocked model' }])
+      expect(subject[:sources_used]).to eq([{ source_last_updated: '2001-01-01T01:01:01Z', last_imported: '2001-01-01T01:01:01Z', source: 'A mocked model' }])
 
       # too wide test for the description
       expect(subject.keys).to match_array([:total, :hits, :offset, :sources_used])
@@ -120,7 +120,7 @@ describe Searchable do
 
     it 'response includes metadata' do
       expect(subject.keys).to include(:sources_used)
-      expect(subject[:sources_used]).to eq([{ source_last_updated: 'a few minutes ago', last_imported: 'a few minutes ago', source: 'A mocked model' }])
+      expect(subject[:sources_used]).to eq([{ source_last_updated: '2001-01-01T01:01:01Z', last_imported: '2001-01-01T01:01:01Z', source: 'A mocked model' }])
 
       # too wide test for the description
       expect(subject.keys).to match_array([:total, :max_score, :hits, :offset, :sources_used])


### PR DESCRIPTION
Points to note:

* `create_index` now also creates its respective metadata doc
* .. this triggers the test enforcement of having the mapping for it defined on the model
  which I believe is correct and was just overlooked before.
* I've removed the code and test for the use case 'when old last_updated format is present in metadata' 
  as all documents should have been migrated by now :-)