### PR TITLE
[#108552098] Admins shouldn't be able to modify data source api field

### DIFF
--- a/app/views/data_sources/_form.html.haml
+++ b/app/views/data_sources/_form.html.haml
@@ -8,5 +8,7 @@
   %p A description of the endpoint (optional; only you see this)
 .field
   = form.label :api
-  = form.text_field :api
-  %p The underscored name that will be in the endpoint URL (e.g., 'de_minimis_currencies')
+  = form.text_field :api, readonly: action_name == 'edit'
+  %p
+    The underscored name that will be in the endpoint URL (e.g., 'de_minimis_currencies').
+    REST conventions suggest using a plural noun to describe the resource in the endpoint.

--- a/spec/features/data_source_spec.rb
+++ b/spec/features/data_source_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature 'Data Source management' do
       expect(page).to have_text('Data source was successfully created. Review the schema and make any changes')
       expect(page).to have_text('Editing data source')
       expect(page).to have_field('Name', with: 'Some human readable name')
+      expect(page).to have_field('Api', readonly: true)
 
       fill_in 'Name', with: 'Some other human readable name'
       click_button 'Update'


### PR DESCRIPTION
text_field is readonly when editing.