### PR TITLE
[#108636862] Developer not constrained by case when making controlled vocab queries

### DIFF
--- a/app/queries/api_model_query.rb
+++ b/app/queries/api_model_query.rb
@@ -28,7 +28,7 @@ class ApiModelQuery < Query
 
   def terms_child(json, field)
     value = instance_variable_get("@#{field}")
-    json.child! { json.terms { json.set! field, csv_to_array(value) } } if value
+    json.child! { json.terms { json.set! field, csv_to_normalized_array(value) } } if value
   end
 
   def date_range_child(json, field)
@@ -36,7 +36,9 @@ class ApiModelQuery < Query
     generate_date_range(json, field, value) if value
   end
 
-  def csv_to_array(value)
-    value.split(',').map(&:strip)
+  def csv_to_normalized_array(value)
+    value.split(',').map do |entry|
+      entry.downcase.squish
+    end
   end
 end

--- a/lib/elasticsearch/model_builder.rb
+++ b/lib/elasticsearch/model_builder.rb
@@ -1,6 +1,6 @@
 module ModelBuilder
   TEMPLATE_PATH = 'lib/elasticsearch/templates/document.rb.erb'.freeze
-  TYPE_TO_MAPPING = { enum:    { type: String, mapping: { type: 'string', index: 'not_analyzed' } },
+  TYPE_TO_MAPPING = { enum:    { type: String, mapping: { type: 'string', analyzer: 'keyword_lowercase' } },
                       integer: { type: Integer },
                       float:   { type: Float },
                       date:    { type: DateTime },

--- a/lib/elasticsearch/templates/document.rb.erb
+++ b/lib/elasticsearch/templates/document.rb.erb
@@ -1,5 +1,5 @@
 require 'elasticsearch/persistence/model'
-
+require 'analyzers'
 module Webservices
   module ApiModels
     Class.new do
@@ -10,7 +10,7 @@ module Webservices
       include Elasticsearch::Persistence::Model
 
       index_name [ES::INDEX_PREFIX, "api_models", '<%= data_source.api %>'].join(':')
-
+      settings(index: { analysis: { analyzer: { keyword_lowercase: Analyzers.definitions[:keyword_lowercase]}}})
       <% data_source.yaml_dictionary.each_pair do |field, metadata| %>
         <% if TYPE_TO_MAPPING[metadata[:type]][:mapping].present? %>
           attribute :<%= field %>, <%= TYPE_TO_MAPPING[metadata[:type]][:type] %>, mapping: <%= TYPE_TO_MAPPING[metadata[:type]][:mapping] %>

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -47,7 +47,8 @@ describe DataSource do
       data_source.ingest
       data_source.with_api_model do |klass|
         expect(klass.count).to eq(2)
-        expect(klass.search(filter: { term: { country: 'Armenia' } }).first.iso2_code).to eq('AM')
+        query = ApiModelQuery.new(data_source, country: 'Armenia')
+        expect(klass.search(query.generate_search_body_hash).first.iso2_code).to eq('AM')
         data_source.update(dictionary: "---\r\n:country_name:\r\n  :source: Country\r\n  :description: Description of Country\r\n  :indexed: true\r\n  :type: enum\r\n:iso2_code:\r\n  :source: ISO-2 code\r\n  :description: Description of ISO-2 code\r\n  :indexed: true\r\n  :type: enum\r\n:de_minimis_value:\r\n  :source: de minimis value\r\n  :description: Description of de minimis value\r\n  :indexed: true\r\n  :type: integer\r\n:de_minimis_currency:\r\n  :source: de minimis currency\r\n  :description: Description of de minimis currency\r\n  :indexed: false\r\n  :type: enum\r\n:vat_amount:\r\n  :source: VAT amount\r\n  :description: Description of VAT amount\r\n  :indexed: true\r\n  :type: float\r\n:vat_currency:\r\n  :source: VAT currency\r\n  :description: Description of VAT currency\r\n  :indexed: true\r\n  :type: enum\r\n:date:\r\n  :source: date\r\n  :description: Description of date\r\n  :indexed: true\r\n  :type: date\r\n:notes:\r\n  :source: Notes\r\n  :description: Description of Notes\r\n  :indexed: true\r\n  :type: string\r\n")
       end
       data_source.ingest
@@ -55,10 +56,37 @@ describe DataSource do
 
     it 'creates entries in the new api index with the new class constant' do
       results = data_source.with_api_model do |klass|
-        klass.search(filter: { term: { country_name: 'Armenia' } })
+        query = ApiModelQuery.new(data_source, country_name: 'Armenia')
+        klass.search(query.generate_search_body_hash)
       end
       expect(results.first.iso2_code).to eq('AM')
       expect(Webservices::ApiModels.constants).to include(:TestCurrency)
+    end
+  end
+
+  describe 'search' do
+    let(:data_source) { DataSource.create(_id: 'recall_and_relevancies', name: 'test', description: 'test API', api: 'recall_and_relevancies', data: "Country,ISO-2 code\r\nAndorra,AD\r\nArmenia,AM\r\nCanada,CA\r\n") }
+    before do
+      data_source.update(dictionary: "---\r\n:country_name:\r\n  :source: Country\r\n  :indexed: true\r\n  :type: enum\r\n:iso2_code:\r\n  :source: ISO-2 code\r\n  :indexed: true\r\n  :type: enum\r\n")
+      data_source.ingest
+    end
+
+    describe 'recall' do
+      it 'matches enum filter terms regardless of case' do
+        results = data_source.with_api_model do |klass|
+          query = ApiModelQuery.new(data_source, country_name: 'ANDORRA', iso2_code: 'aD')
+          klass.search(query.generate_search_body_hash)
+        end
+        expect(results.size).to eq(1)
+      end
+
+      it 'matches multiple filter terms separated by commas' do
+        results = data_source.with_api_model do |klass|
+          query = ApiModelQuery.new(data_source, iso2_code: 'AD, ca')
+          klass.search(query.generate_search_body_hash)
+        end
+        expect(results.size).to eq(2)
+      end
     end
   end
 end


### PR DESCRIPTION
I went about this a little differently than the existing codebase does, in that I downcase the filtered terms in code and then continue to use the more efficient Elasticsearch filtered terms functionality to filter on multiple terms for a field (e.g., `iso2_code=MX,CA`). For this use case, I prefer a simple filter over nesting multiple match queries inside a filter which then goes inside a top-level query. The downside is that you have the `keyword_lowercase` analyzer doing the work at ingest time and the code doing the work at filter time. In this case, the extra analysis is just `.downcase` so I am fine with it.