### PR TITLE
[#107768694] admin can administer multiple versions of endpointme APIs

### DIFF
--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -1,15 +1,25 @@
 class DataSourcesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_data_source, only: [:show, :edit, :update, :destroy]
+  before_action :set_data_source, only: [:show, :edit, :update, :destroy, :iterate_version]
+  rescue_from Elasticsearch::Transport::Transport::Errors::Conflict, with: :api_not_unique
 
   def new
-    @data_source = DataSource.new
+    @data_source = DataSource.new(version_number: 1)
+  end
+
+  def iterate_version
+    @data_source = DataSource.new(name: @data_source.name, api: @data_source.api, description: @data_source.description,
+                                  version_number: @data_source.version_number + 1)
+
+    render :new
   end
 
   def create
-    data_source_params = params.require(:data_source).permit(:name, :api, :description, :path)
-    @data_source = DataSource.new(data_source_params.merge(_id: data_source_params['api'], data: params['data_source']['path'].read))
-    if @data_source.save
+    data_source_params = params.require(:data_source).permit(:name, :api, :description, :path, :version_number)
+    versioned_id = DataSource.id_from_params(data_source_params['api'], data_source_params['version_number'])
+    attributes = data_source_params.merge(_id: versioned_id, data: params['data_source']['path'].read, published: false)
+    @data_source = DataSource.new(attributes)
+    if @data_source.save(op_type: :create, refresh: true)
       redirect_to edit_data_source_path(@data_source), notice: 'Data source was successfully created. Review the schema and make any changes.'
     else
       render :new
@@ -20,7 +30,8 @@ class DataSourcesController < ApplicationController
   end
 
   def update
-    @data_source.update(params.require(:data_source).permit(:name, :api, :description, :dictionary)) && @data_source.ingest
+    attributes = params.require(:data_source).permit(:name, :api, :description, :dictionary, :version_number, :published)
+    @data_source.update(attributes) && @data_source.ingest
     redirect_to data_source_path(@data_source), notice: 'Data source was successfully updated and data uploaded.'
   end
 
@@ -36,5 +47,10 @@ class DataSourcesController < ApplicationController
 
   def set_data_source
     @data_source = DataSource.find(params[:id])
+  end
+
+  def api_not_unique
+    @data_source.errors.add(:api, "'#{@data_source.api}' already exists.")
+    render :new
   end
 end

--- a/app/helpers/data_sources_helper.rb
+++ b/app/helpers/data_sources_helper.rb
@@ -1,6 +1,6 @@
 module DataSourcesHelper
-  def sample_api_call(data_source)
-    url = "/#{data_source.api}/search.json?#{sample_params_from_data_source(data_source)}"
+  def sample_api_call(data_source, with_params = true)
+    url = "/v#{data_source.version_number}/#{data_source.api}/search.json?#{sample_params_from_data_source(data_source, with_params)}"
     link_to url, url
   end
 
@@ -15,11 +15,13 @@ module DataSourcesHelper
 
   private
 
-  def sample_params_from_data_source(data_source)
+  def sample_params_from_data_source(data_source, with_params)
     groups = ["api_key=#{current_user.api_key}"]
-    groups << keys_map(data_source.filter_fields, 'VALUE')
-    groups << keys_map(data_source.date_fields, 'YYYY-MM-DD+TO+YYYY-MM-DD')
-    groups << 'q=TEXT' if data_source.fulltext_fields.present?
+    if with_params
+      groups << keys_map(data_source.filter_fields, 'VALUE')
+      groups << keys_map(data_source.date_fields, 'YYYY-MM-DD+TO+YYYY-MM-DD')
+      groups << 'q=TEXT' if data_source.fulltext_fields.present?
+    end
     groups.compact.join('&')
   end
 

--- a/app/models/concerns/reserved_api_validator.rb
+++ b/app/models/concerns/reserved_api_validator.rb
@@ -1,0 +1,10 @@
+class ReservedApiValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add attribute, (options[:message] || 'exists in the codebase as an endpoint') if api_exists_in_codebase?(value)
+  end
+
+  def api_exists_in_codebase?(value)
+    Rails.application.routes.routes.collect { |route| route.defaults[:controller] }.compact
+      .select { |path| path.starts_with?('api/v') }.map { |path| path.split('/')[2] }.uniq.include?(value)
+  end
+end

--- a/app/views/data_sources/_form.html.haml
+++ b/app/views/data_sources/_form.html.haml
@@ -1,14 +1,23 @@
 .field
   = form.label :name
   = form.text_field :name
-  %p A short, memorable, humanized name for this endpoint (e.g., "De Minimis Currencies")
+  %p A short, memorable, humanized name for this endpoint (e.g., "De Minimis Currencies").
 .field
   = form.label :description
   = form.text_field :description
-  %p A description of the endpoint (optional; only you see this)
+  %p A description of the endpoint (optional; only you see this).
 .field
   = form.label :api
   = form.text_field :api, readonly: action_name == 'edit'
   %p
     The underscored name that will be in the endpoint URL (e.g., 'de_minimis_currencies').
     REST conventions suggest using a plural noun to describe the resource in the endpoint.
+.field
+  = form.label :version_number
+  = form.text_field :version_number, readonly: true
+  %p Versions start with 1, and are referenced in the endpoint as /v1/some_resource.
+- if action_name == 'edit'
+  .field
+    = form.label :published
+    = form.check_box :published
+    %p Whether or not this version of the endpoint has been published to developers yet.

--- a/app/views/data_sources/new.html.haml
+++ b/app/views/data_sources/new.html.haml
@@ -1,4 +1,4 @@
-%h1 New data source
+%h1= "New#{' version of' if action_name == 'iterate_version'} data source"
 
 = form_for @data_source, html: {class: :data_source} do |f|
   - if @data_source.errors.any?

--- a/app/views/data_sources/show.html.haml
+++ b/app/views/data_sources/show.html.haml
@@ -7,6 +7,12 @@
 %p
   %b Api:
   = @data_source.api
+%p
+  %b Published:
+  = @data_source.published
+%p
+  %b Version:
+  = @data_source.version_number
 - if @data_source.filter_fields.present?
   %p
     %b Filtered Fields:
@@ -29,10 +35,17 @@
     %p Specify a date range in this format (e.g., 2013-10-01+TO+2015-10-04)
     %hr
 %p
+  %b API call showing the first page of available data:
+  = sample_api_call @data_source, false
+%p
   %b Sample API call:
   = sample_api_call @data_source
 
-= link_to 'Edit', edit_data_source_path(@data_source)
-\|
+- if @data_source.newest_version?
+  = link_to 'Iterate API Version', iterate_version_data_source_path(@data_source)
+  \|
+  = link_to 'Edit', edit_data_source_path(@data_source)
+  \|
 = link_to 'Back', "/"
-= button_to 'Delete', data_source_path(@data_source), method: :delete, data: { confirm: 'Are you sure you wish to delete this API and data source?' }
+- if @data_source.oldest_version? || @data_source.newest_version?
+  = button_to 'Delete', data_source_path(@data_source), method: :delete, data: { confirm: 'Are you sure you wish to delete this API and data source?' }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,8 +9,8 @@
   <%- if current_user && current_user.admin? %>
     <br>
     <h3>CSV APIs <%= link_to("+", new_data_source_path ) %></h3>
-    <% DataSource.all(_source:{exclude:["data"]}).each do |data_source| %>
-      <p class="view"><%= link_to(data_source.name, url_for(data_source) ) %></p>
+    <% DataSource.directory.each do |data_source| %>
+      <p class="view"><%= link_to("#{data_source.name} (v#{data_source.version_number})", url_for(data_source) ) %></p>
     <% end %>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Webservices::Application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
-  resources :data_sources
+  resources :data_sources do
+    member { get :iterate_version }
+  end
 
   concern :api_v1_routable do
     mapping = {
@@ -116,7 +118,7 @@ Webservices::Application.routes.draw do
   end
 
   scope module: 'api/v2', defaults: { format: :json } do
-    get '/*resource/search(.json)', to: 'api_models#search'
+    get '/v*version_number/*api/search(.json)', to: 'api_models#search', constraints: ApiModelRouteConstraint.new
   end
 
   match '404', via: :all, to: 'api#not_found'

--- a/lib/api_model_route_constraint.rb
+++ b/lib/api_model_route_constraint.rb
@@ -1,0 +1,5 @@
+class ApiModelRouteConstraint
+  def matches?(request)
+    !request.params[:version_number].include?('/')
+  end
+end

--- a/lib/elasticsearch/templates/document.rb.erb
+++ b/lib/elasticsearch/templates/document.rb.erb
@@ -9,8 +9,9 @@ module Webservices
 
       include Elasticsearch::Persistence::Model
 
-      index_name [ES::INDEX_PREFIX, "api_models", '<%= data_source.api %>'].join(':')
       settings(index: { analysis: { analyzer: { keyword_lowercase: Analyzers.definitions[:keyword_lowercase]}}})
+      index_name [ES::INDEX_PREFIX, "api_models", '<%= data_source.api %>', 'v<%= data_source.version_number %>'].join(':')
+
       <% data_source.yaml_dictionary.each_pair do |field, metadata| %>
         <% if TYPE_TO_MAPPING[metadata[:type]][:mapping].present? %>
           attribute :<%= field %>, <%= TYPE_TO_MAPPING[metadata[:type]][:type] %>, mapping: <%= TYPE_TO_MAPPING[metadata[:type]][:mapping] %>

--- a/spec/api/v2/api_models_controller_spec.rb
+++ b/spec/api/v2/api_models_controller_spec.rb
@@ -5,16 +5,17 @@ describe Api::V2::ApiModelsController, type: :request do
   before(:all) do
     csv = File.read "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv"
     dictionary_yaml = File.read "#{Rails.root}/spec/fixtures/data_sources/de_minimis_dictionary.yaml"
-    data_source = DataSource.create(_id: 'de_minimis_currencies', name: 'test', description: 'test API',
-                                    api: 'de_minimis_currencies', data: csv, dictionary: dictionary_yaml)
+    data_source = DataSource.create(_id: 'de_minimis_currencies:v1', name: 'test', description: 'test API',
+                                    api: 'de_minimis_currencies', data: csv, dictionary: dictionary_yaml,
+                                    version_number: 1, published: true)
     data_source.ingest
   end
 
-  describe 'GET /de_minimis_currencies/search.json' do
-    context 'when one document matches a query and filter' do
+  describe 'GET /v1/de_minimis_currencies/search.json' do
+    context 'one document matches a query and filter' do
       let(:one_match) { JSON.parse Rails.root.join("#{File.dirname(__FILE__)}/data_sources/one_match.json").read }
       let(:params) { { q: 'exceeding', date: '2015-10-01 TO 2015-10-02', de_minimis_currency: 'USD' } }
-      before { get '/de_minimis_currencies/search', params, @v2_headers }
+      before { get '/v1/de_minimis_currencies/search', params, @v2_headers }
       subject { response }
 
       it_behaves_like 'a successful search request'
@@ -29,7 +30,7 @@ describe Api::V2::ApiModelsController, type: :request do
       end
 
       it 'includes metadata' do
-        data_source = DataSource.find 'de_minimis_currencies'
+        data_source = DataSource.find 'de_minimis_currencies:v1'
         json_response = JSON.parse(response.body, symbolize_names: true)
         expect(json_response[:sources_used]).to eq(source:              data_source.name,
                                                    source_last_updated: data_source.updated_at.as_json,
@@ -38,5 +39,28 @@ describe Api::V2::ApiModelsController, type: :request do
 
       it_behaves_like "an empty result when a query doesn't match any documents"
     end
+
+    context 'published flag is set to false' do
+      before do
+        data_source = DataSource.new(_id: 'not_published:v1', name: 'test', description: 'test API',
+                                        api: 'not_published', data: 'foo,bar', dictionary: {}.to_yaml,
+                                        version_number: 1, published: false)
+        data_source.save(refresh: true)
+        get '/v1/not_published/search', {}, @v2_headers
+      end
+      subject { response }
+
+      specify { expect(subject.status).to eq(404) }
+    end
+  end
+
+  context 'endpoint does not exist' do
+    before do
+      get '/v9/nope/search', {}, @v2_headers
+    end
+
+    subject { response }
+
+    specify { expect(subject.status).to eq(404) }
   end
 end

--- a/spec/features/data_source_spec.rb
+++ b/spec/features/data_source_spec.rb
@@ -4,12 +4,12 @@ RSpec.feature 'Data Source management' do
   context 'with an admin user' do
     before { create_user(email: 'test@gov.gov', admin: true) }
 
-    scenario 'admin user visits home page' do
+    scenario 'admin user creates, edits, and deletes an API' do
       visit '/'
 
       fill_in 'Email', with: 'test@gov.gov'
       fill_in 'Password', with: 'p4ssword'
-      click_button 'Log in'
+      click_button('Log in')
       expect(page).to have_text('Your API Key is')
       expect(page).to have_text('CSV APIs')
 
@@ -17,31 +17,125 @@ RSpec.feature 'Data Source management' do
       expect(page).to have_text('New data source')
       fill_in 'Description', with: 'Not gonna work'
       attach_file('Path', "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv")
-      click_button 'Create'
+      click_button('Create')
       expect(page).to have_text("Name can't be blank")
       expect(page).to have_text("Api can't be blank")
 
       fill_in 'Name', with: 'Some human readable name'
       fill_in 'Description', with: 'Some human readable desc'
-      fill_in 'Api', with: 'test_currencies'
+      fill_in 'Api', with: 'success_cases'
       attach_file('Path', "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv")
-      click_button 'Create'
+      click_button('Create')
       expect(page).to have_text('Data source was successfully created. Review the schema and make any changes')
       expect(page).to have_text('Editing data source')
       expect(page).to have_field('Name', with: 'Some human readable name')
       expect(page).to have_field('Api', readonly: true)
 
       fill_in 'Name', with: 'Some other human readable name'
-      click_button 'Update'
+      click_button('Update')
       expect(page).to have_text('Data source was successfully updated and data uploaded.')
       expect(page).to have_text('Some other human readable name')
 
       click_link('Back')
-      expect(page).to have_text('Some other human readable name')
+      expect(page).to have_text('Some other human readable name (v1)')
 
-      click_link('Some other human readable name')
+      click_link('Some other human readable name (v1)')
       click_button('Delete')
       expect(page).to have_text('Dataset was successfully destroyed')
+    end
+
+    scenario 'admin user tries to create an already existing API' do
+      visit '/'
+
+      fill_in 'Email', with: 'test@gov.gov'
+      fill_in 'Password', with: 'p4ssword'
+      click_button 'Log in'
+
+      click_link('+')
+      fill_in 'Name', with: 'Some human readable name'
+      fill_in 'Description', with: 'Some human readable desc'
+      fill_in 'Api', with: 'already_exists'
+      attach_file('Path', "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv")
+      click_button('Create')
+
+      click_link('+')
+      fill_in 'Name', with: 'this is a dupe'
+      fill_in 'Description', with: 'should reject it'
+      fill_in 'Api', with: 'already_exists'
+      attach_file('Path', "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv")
+      click_button('Create')
+      expect(page).to have_text("Api 'already_exists' already exists.")
+    end
+
+    scenario 'admin user iterates version of API' do
+      visit '/'
+
+      fill_in 'Email', with: 'test@gov.gov'
+      fill_in 'Password', with: 'p4ssword'
+      click_button 'Log in'
+
+      click_link('+')
+      fill_in 'Name', with: 'Iterate Me'
+      fill_in 'Description', with: 'Iterate Me desc'
+      fill_in 'Api', with: 'nouns'
+      attach_file('Path', "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv")
+      click_button('Create')
+      click_button('Update')
+      expect(page).to have_text('Version: 1')
+
+      click_link('Iterate API Version')
+      expect(page).to have_text('New version of data source')
+      expect(page).to have_field('Version', readonly: true, with: '2')
+      attach_file('Path', "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv")
+      click_button('Create')
+      expect(page).to have_field('Version', readonly: true, with: '2')
+      click_button('Update')
+      expect(page).to have_text('Version: 2')
+
+      click_link('Iterate API Version')
+      attach_file('Path', "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv")
+      click_button('Create')
+      click_button('Update')
+
+      click_link('Iterate Me (v1)')
+      expect(page).to have_text('Version: 1')
+      expect(page).to have_button('Delete')
+      expect(page).not_to have_link('Edit')
+      expect(page).not_to have_link('Iterate API Version')
+
+      click_link('Iterate Me (v2)')
+      expect(page).to have_text('Version: 2')
+      expect(page).not_to have_button('Delete')
+      expect(page).not_to have_link('Edit')
+      expect(page).not_to have_link('Iterate API Version')
+
+      click_link('Iterate Me (v3)')
+      expect(page).to have_text('Version: 3')
+      expect(page).to have_button('Delete')
+      expect(page).to have_link('Edit')
+      expect(page).to have_link('Iterate API Version')
+    end
+
+    scenario 'admin user marks an API as published' do
+      visit '/'
+
+      fill_in 'Email', with: 'test@gov.gov'
+      fill_in 'Password', with: 'p4ssword'
+      click_button 'Log in'
+
+      click_link('+')
+      fill_in 'Name', with: 'Some new API'
+      fill_in 'Description', with: 'Not published yet'
+      fill_in 'Api', with: 'publishing_test'
+      attach_file('Path', "#{Rails.root}/spec/fixtures/data_sources/de_minimis_date.csv")
+      click_button('Create')
+      click_button('Update')
+      expect(page).to have_text('Published: false')
+
+      click_link('Edit')
+      check('Published')
+      click_button('Update')
+      expect(page).to have_text('Published: true')
     end
   end
 end

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -6,10 +6,16 @@ describe DataSource do
       is_expected.to validate_presence_of(:name)
       is_expected.to validate_presence_of(:api)
       is_expected.to validate_presence_of(:data)
+      is_expected.to validate_presence_of(:version_number)
+      is_expected.to validate_numericality_of(:version_number)
     end
 
     ['foo bar', 'de-minimis', "loren's", 'Currencies'].each do |bad_value|
       it { is_expected.not_to allow_value(bad_value).for(:api) }
+    end
+
+    %w(market_researches parature_faq ita_office_locations country_commercial_guides business_service_providers ita_zip_codes ita_taxonomy eccn country_fact_sheets screening_lists tariff_rates trade_leads trade_events envirotech sharepoint_trade_articles trade_articles api_models).each do |existing_api|
+      it { is_expected.not_to allow_value(existing_api).for(:api) }
     end
 
     %w(de_minimis_currencies area_51_residents).each do |ok_value|
@@ -18,7 +24,7 @@ describe DataSource do
   end
 
   describe 'lifecycle callbacks' do
-    let(:data_source) { DataSource.new(_id: 'some_things', name: 'test', description: 'test API', api: 'some_things', data: 'CSV as String') }
+    let(:data_source) { DataSource.new(_id: 'some_things:v2', name: 'test', description: 'test API', api: 'some_things', data: 'CSV as String', version_number: 2) }
 
     before do
       parser = instance_double(DataSourceParser, generate_dictionary: { field1: 'foo', field2: 'bar' })
@@ -34,14 +40,14 @@ describe DataSource do
 
     describe 'destroying a data source' do
       it 'deletes the API index in Elasticsearch' do
-        expect(ES.client.indices).to receive(:delete).with(index: 'test:webservices:api_models:some_things', ignore: 404)
+        expect(ES.client.indices).to receive(:delete).with(index: 'test:webservices:api_models:some_things:v2', ignore: 404)
         data_source.destroy
       end
     end
   end
 
   describe 'ingest' do
-    let(:data_source) { DataSource.create(_id: 'test_currencies', name: 'test', description: 'test API', api: 'test_currencies', data: "Country,ISO-2 code,de minimis value,de minimis currency,VAT amount,VAT currency,date,Notes\r\nAndorra,AD,12,EUR,15.5,,2015-10-01,\r\nArmenia,AM,150000,AMD,,,2015-10-02,\r\n", dictionary: "---\r\n:country:\r\n  :source: Country\r\n  :description: Description of Country\r\n  :indexed: true\r\n  :type: enum\r\n:iso2_code:\r\n  :source: ISO-2 code\r\n  :description: Description of ISO-2 code\r\n  :indexed: true\r\n  :type: enum\r\n:de_minimis_value:\r\n  :source: de minimis value\r\n  :description: Description of de minimis value\r\n  :indexed: true\r\n  :type: integer\r\n:de_minimis_currency:\r\n  :source: de minimis currency\r\n  :description: Description of de minimis currency\r\n  :indexed: false\r\n  :type: enum\r\n:vat_amount:\r\n  :source: VAT amount\r\n  :description: Description of VAT amount\r\n  :indexed: true\r\n  :type: float\r\n:vat_currency:\r\n  :source: VAT currency\r\n  :description: Description of VAT currency\r\n  :indexed: true\r\n  :type: enum\r\n:date:\r\n  :source: date\r\n  :description: Description of date\r\n  :indexed: true\r\n  :type: date\r\n:notes:\r\n  :source: Notes\r\n  :description: Description of Notes\r\n  :indexed: true\r\n  :type: string\r\n") }
+    let(:data_source) { DataSource.create(_id: 'test_currencies:v1', published: true, version_number: 1, name: 'test', description: 'test API', api: 'test_currencies', data: "Country,ISO-2 code,de minimis value,de minimis currency,VAT amount,VAT currency,date,Notes\r\nAndorra,AD,12,EUR,15.5,,2015-10-01,\r\nArmenia,AM,150000,AMD,,,2015-10-02,\r\n", dictionary: "---\r\n:country:\r\n  :source: Country\r\n  :description: Description of Country\r\n  :indexed: true\r\n  :type: enum\r\n:iso2_code:\r\n  :source: ISO-2 code\r\n  :description: Description of ISO-2 code\r\n  :indexed: true\r\n  :type: enum\r\n:de_minimis_value:\r\n  :source: de minimis value\r\n  :description: Description of de minimis value\r\n  :indexed: true\r\n  :type: integer\r\n:de_minimis_currency:\r\n  :source: de minimis currency\r\n  :description: Description of de minimis currency\r\n  :indexed: false\r\n  :type: enum\r\n:vat_amount:\r\n  :source: VAT amount\r\n  :description: Description of VAT amount\r\n  :indexed: true\r\n  :type: float\r\n:vat_currency:\r\n  :source: VAT currency\r\n  :description: Description of VAT currency\r\n  :indexed: true\r\n  :type: enum\r\n:date:\r\n  :source: date\r\n  :description: Description of date\r\n  :indexed: true\r\n  :type: date\r\n:notes:\r\n  :source: Notes\r\n  :description: Description of Notes\r\n  :indexed: true\r\n  :type: string\r\n") }
 
     before do
       data_source.ingest
@@ -65,7 +71,7 @@ describe DataSource do
   end
 
   describe 'search' do
-    let(:data_source) { DataSource.create(_id: 'recall_and_relevancies', name: 'test', description: 'test API', api: 'recall_and_relevancies', data: "Country,ISO-2 code\r\nAndorra,AD\r\nArmenia,AM\r\nCanada,CA\r\n") }
+    let(:data_source) { DataSource.create(_id: 'recall_and_relevancies:v4', published: true, version_number: 4, name: 'test', description: 'test API', api: 'recall_and_relevancies', data: "Country,ISO-2 code\r\nAndorra,AD\r\nArmenia,AM\r\nCanada,CA\r\n") }
     before do
       data_source.update(dictionary: "---\r\n:country_name:\r\n  :source: Country\r\n  :indexed: true\r\n  :type: enum\r\n:iso2_code:\r\n  :source: ISO-2 code\r\n  :indexed: true\r\n  :type: enum\r\n")
       data_source.ingest


### PR DESCRIPTION
- handle case where admin tries to re-create an existing endpointme API
- handle case where admin tries to create an API with the same endpoint as one that's in the codebase
- explicit version number required for search
- admin can create a new version of an existing endpointme API
- admin can only delete the oldest and newest version of an API
- admin can only edit & iterate on most recent version