### PR TITLE
Retain international chars

### DIFF
--- a/app/importers/screening_list/make_name_variants.rb
+++ b/app/importers/screening_list/make_name_variants.rb
@@ -34,7 +34,7 @@ module ScreeningList
     end
 
     def strip(name, target)
-      pattern = target == 'punct' ? /[^a-z0-9\s]/i : /\s+/
+      pattern = target == 'punct' ? /[^\p{Alnum}\p{Space}]/ : /\s+/
       name.class == String ? name.gsub(pattern, '') : name.map { |n| n.gsub(pattern, '') }
     end
 

--- a/app/queries/screening_list/generate_fuzzy_name_query.rb
+++ b/app/queries/screening_list/generate_fuzzy_name_query.rb
@@ -10,7 +10,7 @@ module ScreeningList
       name_no_wss   = %w( name_no_ws name_no_ws_rev alt_no_ws alt_no_ws_rev
                           name_no_ws_with_common name_no_ws_rev_with_common alt_no_ws_with_common alt_no_ws_rev_with_common )
 
-      @name = @name.gsub(/[^a-z0-9\s]/i, '')
+      @name = @name.gsub(/[^\p{Alnum}\p{Space}]/, '')
       @name = @name.split.delete_if { |name| stopwords.include?(name.downcase) }.join(' ')
       @name = @name.split.delete_if { |name| common_words.include?(name.downcase) }.join(' ')
 


### PR DESCRIPTION
Related to #109373518. Replaced alpha num regex for gsub with properties (similar to posix char classes).