### PR TITLE
[#108444844] Upgrade elasticsearch to the latest 2.x version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 bundler_args: --without development staging production
 language: ruby
 sudo: false
-services:
-  - elasticsearch
+
+env:
+  - ES_VERSION=2.2.0
 
 addons:
- code_climate:
-   repo_token: b2be59fc94d6de5b889a16c640227b42d40d8aa21df90fad79dd70f2687d630c
+  code_climate:
+    repo_token: b2be59fc94d6de5b889a16c640227b42d40d8aa21df90fad79dd70f2687d630c
+
+before_install:
+  - "mkdir /tmp/elasticsearch"
+  - "wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1"
+  - "/tmp/elasticsearch/bin/plugin install delete-by-query"
+  - 'echo ''index.number_of_shards: 1'' | tee --append /tmp/elasticsearch/config/elasticsearch.yml'
+  - "/tmp/elasticsearch/bin/elasticsearch &"
+  - "sleep 10"
 
 notifications:
   slack: govwizely:R9Nhshn0NO7eRh4ThXaMKqWw

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,10 +116,10 @@ GEM
     docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (1.0.8)
-      elasticsearch-api (= 1.0.7)
-      elasticsearch-transport (= 1.0.7)
-    elasticsearch-api (1.0.7)
+    elasticsearch (1.0.15)
+      elasticsearch-api (= 1.0.15)
+      elasticsearch-transport (= 1.0.15)
+    elasticsearch-api (1.0.15)
       multi_json
     elasticsearch-model (0.1.7)
       activesupport (> 3)
@@ -132,13 +132,13 @@ GEM
       elasticsearch-model (>= 0.1)
       hashie
       virtus
-    elasticsearch-transport (1.0.7)
+    elasticsearch-transport (1.0.15)
       faraday
       multi_json
     equalizer (0.0.11)
     erubis (2.7.0)
     eventmachine (1.0.7)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
@@ -192,7 +192,7 @@ GEM
       money (~> 6.5.0)
     money (6.5.1)
       i18n (>= 0.6.4, <= 0.7.0)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-http-digest_auth (1.4)

--- a/README.md
+++ b/README.md
@@ -48,11 +48,15 @@ More information about the gem can be found [here](https://github.com/brianmario
 
 ### ElasticSearch
 
-We're using [ElasticSearch](http://www.elasticsearch.org/) (>= 1.2.0) for fulltext search. On a Mac, it's easy to install with [Homebrew](http://mxcl.github.com/homebrew/).
+We're using [ElasticSearch](http://www.elasticsearch.org/) (>= 2.2.0) for fulltext search. On a Mac, it's easy to install with [Homebrew](http://mxcl.github.com/homebrew/).
 
     brew install elasticsearch
 
 Otherwise, follow the [instructions](http://www.elasticsearch.org/download/) to download and run it.
+
+You need to install the delete-by-query plugin and restart elasticsearch if it was already running:
+
+    $ plugin install delete-by-query
 
 Webservices can use foreman to start Rails and Sidekiq in development environments. 
 

--- a/app/importers/concerns/importable.rb
+++ b/app/importers/concerns/importable.rb
@@ -20,7 +20,7 @@ module Importable
   module Prepend
     def import
       Rails.logger.info "#{self.class.name}: import starting."
-      start_time = Time.now if can_purge_old?
+      start_time = Time.now.utc.iso8601(8) if can_purge_old?
       super
       model_class.purge_old(start_time) if can_purge_old?
       model_class.touch_metadata

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -55,10 +55,7 @@ class DataSource
     timestamp = updated_timestamp
     if message_digest != new_message_digest
       update(data: data, message_digest: new_message_digest, data_changed_at: timestamp, data_imported_at: timestamp)
-      with_api_model do |klass|
-        _ingest(klass)
-        ES.client.delete_by_query(index: klass.index_name, type: klass.document_type, body: older_than(:_updated_at, updated_at))
-      end
+      ingest_and_prune
     else
       touch(:data_imported_at)
     end
@@ -140,8 +137,17 @@ class DataSource
     @metadata = nil
   end
 
+  def ingest_and_prune
+    with_api_model do |klass|
+      _ingest(klass)
+      ES.client.delete_by_query(index: klass.index_name, type: klass.document_type, body: older_than(:_updated_at, updated_at))
+      klass.refresh_index!
+    end
+  end
+
   def _ingest(klass)
     "DataSources::#{data_format}Ingester".constantize.new(klass, metadata, data).ingest
+    klass.refresh_index!
   end
 
   def updated_timestamp

--- a/app/models/ita_taxonomy.rb
+++ b/app/models/ita_taxonomy.rb
@@ -15,12 +15,9 @@ class ItaTaxonomy
 
   self.mappings = {
     name.typeize => {
-      _timestamp: {
-        enabled: true,
-        store:   true,
-      },
       dynamic:    'false',
       properties: {
+        _updated_at:    { type: 'date', format: 'strictDateOptionalTime' },
         name:           { type: 'string', analyzer: 'standard' },
         taxonomies:     { type: 'string', analyzer: 'lowercase_keyword_analyzer' },
         path:           { type: 'string', index: 'not_analyzed'  },

--- a/app/models/ita_zip_code.rb
+++ b/app/models/ita_zip_code.rb
@@ -8,12 +8,9 @@ class ItaZipCode
 
   self.mappings = {
     name.typeize => {
-      _timestamp: {
-        enabled: true,
-        store:   true,
-      },
       dynamic:    'false',
       properties: {
+        _updated_at:       { type: 'date', format: 'strictDateOptionalTime' },
         zip_code:          { type: 'string' },
         zip_city:          { type: 'string', analyzer: 'location_name_analyzer' },
         post:              {

--- a/app/models/parature_faq.rb
+++ b/app/models/parature_faq.rb
@@ -6,17 +6,14 @@ class ParatureFaq
 
   self.mappings = {
     name.typeize => {
-      _timestamp: {
-        enabled: true,
-        store:   true,
-      },
       dynamic:    'false',
       properties: {
-        question:       { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
-        answer:         { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
-        update_date:    { type: 'date', format: 'YYYY-MM-dd' },
-        topic:          { type: 'string', analyzer: 'keyword_lowercase' },
-        industry:       { type: 'string', analyzer: 'keyword_lowercase' },
+        _updated_at: { type: 'date', format: 'strictDateOptionalTime' },
+        question:    { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
+        answer:      { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
+        update_date: { type: 'date', format: 'YYYY-MM-dd' },
+        topic:       { type: 'string', analyzer: 'keyword_lowercase' },
+        industry:    { type: 'string', analyzer: 'keyword_lowercase' },
         country:        { type: 'string', analyzer: 'keyword_lowercase' },
         ita_industries: { type: 'string', analyzer: 'keyword_lowercase' },
       },

--- a/app/models/salesforce_article/mappable.rb
+++ b/app/models/salesforce_article/mappable.rb
@@ -7,11 +7,8 @@ module SalesforceArticle
 
       klass.mappings = {
         klass.name.typeize => {
-          _timestamp: {
-            enabled: true,
-            store:   true,
-          },
           properties: {
+            _updated_at:          { type: 'date', format: 'strictDateOptionalTime' },
             atom:                 { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
             business_unit:        { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
             chapter:              { type: 'string', analyzer: 'snowball_asciifolding_nostop' },

--- a/app/models/screening_list/mappable.rb
+++ b/app/models/screening_list/mappable.rb
@@ -7,11 +7,8 @@ module ScreeningList
 
       klass.mappings = {
         klass.name.typeize => {
-          _timestamp: {
-            enabled: true,
-            store:   true,
-          },
           properties: {
+            _updated_at:                { type: 'date', format: 'strictDateOptionalTime' },
             # name variants
             name:                       { type:     'string',
                                           analyzer: 'standard_asciifolding_nostop',

--- a/app/models/sharepoint_trade_article.rb
+++ b/app/models/sharepoint_trade_article.rb
@@ -7,11 +7,8 @@ class SharepointTradeArticle
   self.mappings = {
 
     sharepoint_trade_article: {
-      _timestamp: {
-        enabled: true,
-        store:   true,
-      },
       properties: {
+        _updated_at:              { type: 'date', format: 'strictDateOptionalTime' },
         title:                    { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
         short_title:              { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
         summary:                  { type: 'string', analyzer: 'snowball_asciifolding_nostop' },

--- a/app/models/trade_event/mappable.rb
+++ b/app/models/trade_event/mappable.rb
@@ -7,11 +7,8 @@ module TradeEvent
 
       klass.mappings = {
         klass.name.typeize => {
-          _timestamp: {
-            enabled: true,
-            store:   true,
-          },
           properties: {
+            _updated_at:        { type: 'date', format: 'strictDateOptionalTime' },
             cost:               { type: 'float' },
             country:            { type: 'string', analyzer: 'keyword' },
             state:              { type: 'string', analyzer: 'keyword' },

--- a/app/models/trade_lead/mappable.rb
+++ b/app/models/trade_lead/mappable.rb
@@ -6,11 +6,8 @@ module TradeLead
 
       klass.mappings = {
         klass.name.typeize => {
-          _timestamp: {
-            enabled: true,
-            store:   true,
-          },
           properties: {
+            _updated_at:              { type: 'date', format: 'strictDateOptionalTime' },
             country:                  { type: 'string', analyzer: 'keyword' },
             description:              { type: 'string', analyzer: 'snowball_asciifolding_nostop' },
             contract_number:          { type: 'string', index: 'not_analyzed' },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,11 +30,11 @@ Webservices::Application.routes.draw do
   end
 
   concern :api_routable do
-    mapping = { 'market_researches'         => 'market_research_library',
-                'parature_faq'              => 'ita_faqs',
-                'ita_office_locations'      => 'ita_office_locations',
-                'ita_zip_codes'             => 'ita_zipcode_to_post',
-                'ita_taxonomy'              => 'ita_taxonomies',
+    mapping = { 'market_researches'    => 'market_research_library',
+                'parature_faq'         => 'ita_faqs',
+                'ita_office_locations' => 'ita_office_locations',
+                'ita_zip_codes'        => 'ita_zipcode_to_post',
+                'ita_taxonomy'         => 'ita_taxonomies',
      }
 
     mapping.each do |controller, path|
@@ -60,7 +60,6 @@ Webservices::Application.routes.draw do
     scope '/market_intelligence' do
       get 'search', to: 'salesforce_articles/consolidated#search'
     end
-
   end
 
   scope 'v2', module: 'api/v2', defaults: { format: :json } do

--- a/spec/api/v2/screening_lists/consolidated_spec.rb
+++ b/spec/api/v2/screening_lists/consolidated_spec.rb
@@ -40,7 +40,6 @@ describe 'Consolidated Screening List API V2', type: :request do
       it_behaves_like 'it contains only results with sources' do
         let(:sources) { [ScreeningList::Sdn] }
       end
-
     end
 
     context 'when address is specified' do

--- a/spec/importers/concerns/versionable_resource_spec.rb
+++ b/spec/importers/concerns/versionable_resource_spec.rb
@@ -6,9 +6,8 @@ describe VersionableResource do
       include Indexable
       self.mappings = {
         name.typeize => {
-          _timestamp: {
-            enabled: true,
-            store:   true,
+          properties: {
+            _updated_at: { type: 'date', format: 'strictDateOptionalTime' },
           },
         },
       }

--- a/spec/lib/url_mapper_spec.rb
+++ b/spec/lib/url_mapper_spec.rb
@@ -1,12 +1,15 @@
 require 'spec_helper'
 
 describe UrlMapper do
+  let(:now) { Time.now.utc }
+
   before do
     UrlMapper.recreate_index
-    UrlMapper.index([{ id:       Digest::SHA1.hexdigest('http://www.google.com'),
-                       link:     'http://bit.ly/randomid',
-                       long_url: 'http://www.google.com',
-                       title:    'Title' }])
+    UrlMapper.index([{ id:          Digest::SHA1.hexdigest('http://www.google.com'),
+                       link:        'http://bit.ly/randomid',
+                       long_url:    'http://www.google.com',
+                       title:       'Title',
+                       _updated_at: now }])
   end
 
   describe '#get_bitly_url' do
@@ -56,7 +59,7 @@ describe UrlMapper do
                                                       _type:   'url_mapper',
                                                       _id:     '738ddf35b3a85a7a6ba7b232bd3d5f1e4d284ad1',
                                                       _score:  1.0,
-                                                      _source: { link: 'http://bit.ly/randomid', long_url: 'http://www.google.com', title: 'Title' } }] }
+                                                      _source: { link: 'http://bit.ly/randomid', long_url: 'http://www.google.com', title: 'Title', _updated_at: now.strftime('%FT%TZ') } }] }
       expect(UrlMapper.search_for_url('http://www.google.com')).to eq(expected)
     end
   end
@@ -83,11 +86,11 @@ describe UrlMapper do
 
   describe '#purge_old' do
     it 'purges documents that are older than two months' do
-      UrlMapper.index([{ id:        Digest::SHA1.hexdigest('http://www.someurl.com'),
-                         link:      'http://bit.ly/someid',
-                         long_url:  'http://www.someurl.com',
-                         title:     'Old Entry',
-                         timestamp: (Date.current - 65) }])
+      UrlMapper.index([{ id:          Digest::SHA1.hexdigest('http://www.someurl.com'),
+                         link:        'http://bit.ly/someid',
+                         long_url:    'http://www.someurl.com',
+                         title:       'Old Entry',
+                         _updated_at: (Date.current - 65) }])
       expect(UrlMapper.search_for_url('http://www.someurl.com')[:hits].count).to eq(1)
       UrlMapper.purge_old
       expect(UrlMapper.search_for_url('http://www.someurl.com')[:hits].count).to eq(0)

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -7,12 +7,9 @@ describe Searchable do
       self.fetch_all_sort_by = 'foo'
       self.mappings = {
         name.typeize => {
-          _timestamp: {
-            enabled: true,
-            store:   true,
-          },
           properties: {
-            foo: { type: 'string' },
+            foo:         { type: 'string' },
+            _updated_at: { type: 'date', format: 'strictDateOptionalTime' },
           },
         },
       }

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -222,7 +222,6 @@ describe DataSource do
         sleep(1.1)
         data_source.dictionary = "---\r\n:f1:\r\n  :source: f1\r\n  :description: Description of f1\r\n  :indexed: true\r\n  :plural: true\r\n  :type: enum\r\n:f2:\r\n  :source: f2\r\n  :description: Description of f2\r\n  :indexed: true\r\n  :plural: true\r\n  :type: enum\r\n"
         data_source.freshen
-        DataSource.refresh_index!
         data_source.with_api_model do |klass|
           expect(klass.count).to eq(2)
           query = ApiModelQuery.new(data_source.metadata, ActionController::Parameters.new(f1: 'one,three'))


### PR DESCRIPTION
This commit just restructures the indexes to no longer use the _timestamp or _ttl metadata. It will require essentially all API endpoint indexes to be rebuilt. Once that is done and the elasticsearch migration plugin no longer reports any issues (aside from blue-colored warnings about booleans), then it should be safe to upgrade Elasticsearch.