### PR TITLE
[#116229911] CSV/TSV files containing fields with leading zero should not be cast to floats

### DIFF
--- a/app/importers/data_sources/sv_ingester.rb
+++ b/app/importers/data_sources/sv_ingester.rb
@@ -6,7 +6,7 @@ module DataSources
     end
 
     def ingest
-      ingest_sv_options = { converters:        [->(f) { f ? f.squish : nil }, :date, :numeric],
+      ingest_sv_options = { converters:        [->(f) { f ? f.squish : nil }],
                             header_converters: [->(f) { convert_header(f) }],
                             headers:           true,
                             col_sep:           @col_sep,

--- a/spec/fixtures/data_sources/currencies.csv
+++ b/spec/fixtures/data_sources/currencies.csv
@@ -1,3 +1,3 @@
-Country,ISO-2 code,de minimis value,de minimis currency,VAT amount,vatcurrency,date,Notes
-Andorra,AD,12,EUR,15.5,EUR,2015-10-01,
-Armenia,AM,150000,AMD,,,2015-10-02,some notes
+tariff_line,Country,ISO-2 code,de minimis value,de minimis currency,VAT amount,vatcurrency,date,Notes
+01011000,Andorra,AD,12,EUR,15.5,EUR,2015-10-01,
+010210,Armenia,AM,150000,AMD,,,2015-10-02,some notes

--- a/spec/fixtures/data_sources/currencies.yaml
+++ b/spec/fixtures/data_sources/currencies.yaml
@@ -1,4 +1,10 @@
 ---
+:tariff_line:
+  :source: tariff_line
+  :description: Description of tariff_line
+  :indexed: true
+  :plural: false
+  :type: enum
 :country_name:
   :source: Country
   :description: Description of Country

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -69,6 +69,7 @@ describe DataSource do
         end
         expect(results.first.iso_code).to eq('AM')
         expect(Webservices::ApiModels.constants).to include(:TestCurrency)
+        expect(results.first.tariff_line).to eq('010210')
       end
     end
 


### PR DESCRIPTION
- Don't cast values to :date, :numeric when reading from CSV/TSV files