### PR TITLE
[Fixes #118680981] Some country names incorrect for MCA trade leads

### DIFF
--- a/app/importers/trade_lead/mca_data.rb
+++ b/app/importers/trade_lead/mca_data.rb
@@ -4,6 +4,7 @@ module TradeLead
   class McaData
     include Importable
     include VersionableResource
+    include McaImporter::McaCountryData
     ENDPOINT = 'http://www.dgmarket.com/tenders/RssFeedAction.do?locationISO=&keywords=Millennium+Challenge+Account&sub=&noticeType=gpn%2cpp%2cspn%2crfc&language'
     FUNDING_SOURCE = 'Millennium Challenge Account (MCA)'
 
@@ -44,8 +45,8 @@ module TradeLead
 
     def process_geo_fields(item_hash)
       country = item_hash[:categories].delete_at(item_hash[:categories].find_index { |e| /country\// =~ e })
-      item_hash[:country] = lookup_country(country.match(/country\/(\w\w)/)[1].upcase)
-      item_hash[:country_name] = country.match(/- ([a-zA-Z]+)/)[1]
+      item_hash[:country] = lookup_country(extract_iso2_code(country))
+      item_hash[:country_name] = extract_country_name(country)
       item_hash.merge! add_related_fields([item_hash[:country_name]])
     end
 

--- a/app/importers/trade_lead/mca_importer/mca_country_data.rb
+++ b/app/importers/trade_lead/mca_importer/mca_country_data.rb
@@ -1,0 +1,13 @@
+module TradeLead
+  module McaImporter
+    module McaCountryData
+      def extract_iso2_code(mca_country_string)
+        mca_country_string.match(/country\/(\w\w)/)[1].upcase
+      end
+
+      def extract_country_name(mca_country_string)
+        mca_country_string.match(/- ([a-zA-Z ]+)/)[1]
+      end
+    end
+  end
+end

--- a/spec/importers/trade_lead/mca_importer/mca_country_data_spec.rb
+++ b/spec/importers/trade_lead/mca_importer/mca_country_data_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe TradeLead::McaImporter::McaCountryData do
+  let(:mca_class) { Class.new { include TradeLead::McaImporter::McaCountryData } }
+  let(:mca_country_string) { 'country/us - United States' }
+  describe 'extract_iso2_code(mca_country_string)' do
+    subject{mca_class.new.extract_iso2_code(mca_country_string)}
+    it { is_expected.to eq('US') }
+  end
+  describe 'extract_country_name(mca_country_string)' do
+    subject{mca_class.new.extract_country_name(mca_country_string)}
+    it { is_expected.to eq('United States') }
+  end
+end


### PR DESCRIPTION
- Handle country names containing more than one token/word like 'United States'
- Also fixes downstream problem where related fields end up blank