### PR TITLE
Lock rubocop at 0.39.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'foreman'
-  gem 'rubocop', require: false
+  gem 'rubocop', '0.39.0', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,8 +279,8 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.40.0)
-      parser (>= 2.3.1.0, < 3.0)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -400,7 +400,7 @@ DEPENDENCIES
   roo
   roo-xls
   rspec-rails
-  rubocop
+  rubocop (= 0.39.0)
   rubyzip
   sanitize
   sass

--- a/app/views/api/v2/ita_taxonomy/search.json.jbuilder
+++ b/app/views/api/v2/ita_taxonomy/search.json.jbuilder
@@ -4,6 +4,6 @@ json.results do
     entry = hit.deep_symbolize_keys
     json.id entry[:_id]
     json.call(entry[:_source], :label, :type, :sub_class_of,
-              :annotations, :datatype_properties, :object_properties, :related_terms)
+              :annotations, :datatype_properties, :object_properties, :related_terms,)
   end
 end

--- a/app/views/api/v2/ita_taxonomy/show.json.jbuilder
+++ b/app/views/api/v2/ita_taxonomy/show.json.jbuilder
@@ -1,4 +1,4 @@
 entry = @search[:hits].first.deep_symbolize_keys
 json.id entry[:_id]
 json.call(entry[:_source], :label, :type, :sub_class_of,
-          :annotations, :datatype_properties, :object_properties, :related_terms)
+          :annotations, :datatype_properties, :object_properties, :related_terms,)


### PR DESCRIPTION
When I ran `rubocop -a` with version 0.40.0 it tidied the code incorrectly, causing a syntax error. Given that rubocop is used only in development it isn't a security concern to lock it down like this. I'll review the situation in a month or two...