### PR TITLE
[#125249461] Ensure params sent to external mappers are encoded properly

### DIFF
--- a/app/importers/data_sources/external_mapping_transformation.rb
+++ b/app/importers/data_sources/external_mapping_transformation.rb
@@ -18,7 +18,7 @@ module DataSources
       url_template = hash[:url]
       result_path = hash[:result_path]
       multi_value = hash[:multi_value]
-      url = url_template.sub('ORIGINAL_VALUE', URI.encode(value))
+      url = url_template.sub('ORIGINAL_VALUE', ParamEncoder.encode(value))
       result = JsonPath.on(json_response_from(url), result_path)
       result = result.first unless multi_value
       result

--- a/lib/param_encoder.rb
+++ b/lib/param_encoder.rb
@@ -1,0 +1,5 @@
+module ParamEncoder
+  def self.encode(value)
+    CGI.escape(value).gsub('+','%20')
+  end
+end

--- a/spec/lib/param_encoder_spec.rb
+++ b/spec/lib/param_encoder_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe ParamEncoder do
+  describe 'handling spaces' do
+    subject { ParamEncoder.encode('foo bar') }
+
+    it { should eq('foo%20bar')}
+  end
+
+  describe 'handling special characters like ampersands commonly found in URLs' do
+    subject { ParamEncoder.encode('http://www.foo.gov?x=1&y=2') }
+
+    it { should eq('http%3A%2F%2Fwww.foo.gov%3Fx%3D1%26y%3D2')}
+  end
+end


### PR DESCRIPTION
- Seems like the least worst way, based on http://stackoverflow.com/a/8434235