### PR TITLE
[#126611613] get trade_lead by ID for consolidated feeds

### DIFF
--- a/app/controllers/api/v2/api_models_controller.rb
+++ b/app/controllers/api/v2/api_models_controller.rb
@@ -11,9 +11,11 @@ class Api::V2::ApiModelsController < Api::V2Controller
   end
 
   def show
-    @data_source.with_api_model { |api_model_klass| respond_with api_model_klass.find(params[:id]) }
-  rescue Elasticsearch::Persistence::Repository::DocumentNotFound
-    not_found
+    query = IdsQuery.new([params[:id]])
+    data_source_search = DataSources::Search.new(@data_source, query, nil)
+    search_response_hash = data_source_search.search
+    record = search_response_hash[:results].first
+    record ? respond_with(record) : not_found
   end
 
   private

--- a/lib/ids_query.rb
+++ b/lib/ids_query.rb
@@ -1,0 +1,18 @@
+class IdsQuery
+  attr_reader :offset
+
+  def initialize(ids)
+    @ids = ids
+    @offset = 0
+  end
+
+  def generate_search_body_hash
+    Jbuilder.new do |json|
+      json.query do
+        json.ids do
+          json.values @ids
+        end
+      end
+    end.attributes!
+  end
+end

--- a/lib/param_encoder.rb
+++ b/lib/param_encoder.rb
@@ -1,5 +1,5 @@
 module ParamEncoder
   def self.encode(value)
-    CGI.escape(value).gsub('+','%20')
+    CGI.escape(value).gsub('+', '%20')
   end
 end

--- a/spec/api/v2/api_models_controller_spec.rb
+++ b/spec/api/v2/api_models_controller_spec.rb
@@ -18,7 +18,7 @@ describe Api::V2::ApiModelsController, type: :request do
   describe 'GET /v1/de_minimis_currencies/{id}' do
     context 'record exists' do
       let(:one_match) { JSON.parse Rails.root.join("#{Rails.root}/spec/fixtures/data_sources/de_minimis_date_entry.json").read }
-      let(:id) { Digest::SHA1.hexdigest('Azerbaijan') }
+      let(:id) { '213598a7e92217bee3a758f3c69aea09ed940c0e' }
       before { get "/v1/de_minimis_currencies/#{id}", {}, @v2_headers }
       subject { response }
 

--- a/spec/features/consolidated_data_source_spec.rb
+++ b/spec/features/consolidated_data_source_spec.rb
@@ -48,6 +48,9 @@ RSpec.feature 'Consolidated Data Source management' do
       expect(page).not_to have_text('this is about a pony')
       expect(page).to have_text('ponies are nice')
       expect(page).not_to have_text('horses are bigger')
+
+      visit("/v1/consolidated_entries/6982cd2dd350cc4d0729de5db16502da176fa5d6?api_key=#{@user.api_key}")
+      expect(page).to have_text('6982cd2dd350cc4d0729de5db16502da176fa5d6')
     end
   end
 end

--- a/spec/lib/index_monitor_spec.rb
+++ b/spec/lib/index_monitor_spec.rb
@@ -50,7 +50,7 @@ describe IndexMonitor do
   end
 
   describe '#get_metadata' do
-    before do 
+    before do
       class Mock3
         include Indexable
         self.mappings = {}
@@ -67,7 +67,7 @@ describe IndexMonitor do
 
     it 'returns the correct metadata when import_rate is found' do
       index_name = Mock.index_name
-      expect(monitor.get_metadata(index_name)).to eq({version: "", last_updated: "", last_imported: "", import_rate: "Daily"})
+      expect(monitor.get_metadata(index_name)).to eq(version: '', last_updated: '', last_imported: '', import_rate: 'Daily')
     end
   end
 end

--- a/spec/lib/param_encoder_spec.rb
+++ b/spec/lib/param_encoder_spec.rb
@@ -4,12 +4,12 @@ describe ParamEncoder do
   describe 'handling spaces' do
     subject { ParamEncoder.encode('foo bar') }
 
-    it { should eq('foo%20bar')}
+    it { should eq('foo%20bar') }
   end
 
   describe 'handling special characters like ampersands commonly found in URLs' do
     subject { ParamEncoder.encode('http://www.foo.gov?x=1&y=2') }
 
-    it { should eq('http%3A%2F%2Fwww.foo.gov%3Fx%3D1%26y%3D2')}
+    it { should eq('http%3A%2F%2Fwww.foo.gov%3Fx%3D1%26y%3D2') }
   end
 end


### PR DESCRIPTION
- set record ID explicitly in GET /v1/de_minimis_currencies/{id} test, as the ID isn't created via simple SHA1 of the value anymore.
